### PR TITLE
オフライン対応とスリープ復帰更新を追加

### DIFF
--- a/web/src/pages/Dashboard.vue
+++ b/web/src/pages/Dashboard.vue
@@ -22,6 +22,8 @@ const refreshFailed = ref(false)
 const operationError = ref('')
 const lastUpdatedAt = ref<Date | null>(null)
 const pendingIDs = ref<number[]>([])
+const isOffline = ref(!navigator.onLine)
+const isLoadingDashboard = ref(false)
 
 let pollTimer: number | undefined
 let tempIDSeed = -1
@@ -80,6 +82,11 @@ function getOperationErrorMessage(err: unknown): string {
 }
 
 async function loadDashboard(): Promise<void> {
+  if (isOffline.value || isLoadingDashboard.value) {
+    return
+  }
+
+  isLoadingDashboard.value = true
   try {
     const data = await fetchDashboard()
     normalizeNotesOrder(data)
@@ -96,6 +103,7 @@ async function loadDashboard(): Promise<void> {
     }
   } finally {
     loading.value = false
+    isLoadingDashboard.value = false
   }
 }
 
@@ -269,17 +277,60 @@ const lastUpdatedLabel = computed(() => {
   }).format(lastUpdatedAt.value)
 })
 
-onMounted(async () => {
-  await loadDashboard()
+function startPolling(): void {
+  if (pollTimer !== undefined || isOffline.value) {
+    return
+  }
   pollTimer = window.setInterval(() => {
     void loadDashboard()
   }, 30_000)
+}
+
+function stopPolling(): void {
+  if (pollTimer === undefined) {
+    return
+  }
+  window.clearInterval(pollTimer)
+  pollTimer = undefined
+}
+
+function handleVisibilityChange(): void {
+  if (document.visibilityState === 'visible' && !isOffline.value) {
+    void loadDashboard()
+  }
+}
+
+function handleOffline(): void {
+  isOffline.value = true
+  stopPolling()
+}
+
+function handleOnline(): void {
+  isOffline.value = false
+  startPolling()
+  void loadDashboard()
+}
+
+onMounted(async () => {
+  window.addEventListener('offline', handleOffline)
+  window.addEventListener('online', handleOnline)
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+
+  if (isOffline.value) {
+    loading.value = false
+    stopPolling()
+    return
+  }
+
+  await loadDashboard()
+  startPolling()
 })
 
 onUnmounted(() => {
-  if (pollTimer !== undefined) {
-    window.clearInterval(pollTimer)
-  }
+  stopPolling()
+  window.removeEventListener('offline', handleOffline)
+  window.removeEventListener('online', handleOnline)
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
 })
 </script>
 
@@ -288,8 +339,9 @@ onUnmounted(() => {
     <header class="header">
       <h1>HomeDash</h1>
       <div class="status">
-        <span>最終更新 {{ lastUpdatedLabel }}</span>
+        <span>更新: {{ lastUpdatedLabel }}</span>
         <span v-if="refreshFailed" class="status-error">更新失敗</span>
+        <span v-if="isOffline" class="status-offline">オフライン</span>
       </div>
     </header>
 
@@ -348,6 +400,11 @@ h1 {
 
 .status-error {
   color: #b00020;
+  font-weight: 700;
+}
+
+.status-offline {
+  color: #0b5fa8;
   font-weight: 700;
 }
 


### PR DESCRIPTION
## 概要
MVP0の機能追加は行わず、タブレット実運用での安定性を強化しました。
スリープ復帰・オフライン・再接続時の挙動を `Dashboard.vue` で改善しています。

## 変更内容
- `visibilitychange` 監視を追加
  - 非表示→表示時に `dashboard` を即再取得
- `online/offline` 監視を追加
  - オフライン時: `オフライン` 表示 + ポーリング停止
  - オンライン復帰時: 即再取得 + ポーリング再開
- ポーリング制御を整理
  - オンライン時のみ30秒ポーリング
  - オフライン時は停止
- 取得処理のガードを追加
  - オフライン時・取得中重複時は再取得を抑止
- 状態表示を改善
  - `更新: HH:mm`
  - `更新失敗`
  - `オフライン`
- 既存のエラー耐性は維持
  - 取得失敗時に前回データを保持
  - UIを壊さず継続利用可能

## 変更ファイル
- web/src/pages/Dashboard.vue

## 確認手順
1. `docker compose up --build`
2. `http://localhost:8080` を開く
3. スリープ復帰またはタブを非表示→表示し、30秒待たず更新されること
4. ネットワーク切断で `オフライン` が表示されること
5. ネットワーク復帰で自動再取得されること
6. API失敗時でも既存表示が維持され、`更新失敗` が表示されること

## 実行結果
- `cd web && npm run build`: 成功
- `go test ./...`: 成功
- `docker compose up --build -d`: 成功
- `GET /`: 200
- `GET /api/v1/dashboard`: 200
