### PR TITLE
簡易トークン認証を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ DB_PATH=/data/app.db
 GARBAGE_SCHEDULE_PATH=config/garbage_schedule.json
 WEB_DIST_PATH=web/dist
 CORS_ALLOW_ORIGINS=
+# 任意: 設定すると /api/v1/* で Bearer 認証を有効化
+AUTH_TOKEN=replace-with-long-random-token

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ MVP0では次の3機能に限定しています。
 - Docker前提で運用する
 - データはローカル保存する（SQLite / 設定ファイル）
 
+## 運用モード（認証）
+
+### 家庭内LANモード（既定）
+
+- `AUTH_TOKEN` 未設定
+- 今まで通り認証なしで利用
+
+### VPN/外部アクセス想定モード（推奨）
+
+- `AUTH_TOKEN` を設定
+- `/api/v1/*` は `Authorization: Bearer <token>` が必須
+- `/`（Vue画面）は開けますが、トークンなしではAPIが `401` になり画面に認証エラーが表示されます
+
 ## 起動方法
 
 1. 必要に応じて `.env.example` をもとに `.env` を作成
@@ -53,6 +66,7 @@ docker compose down
 - `APP_ADDR`（デフォルト: `:8080`）
 - `DB_PATH`（デフォルト: `/data/app.db`）
 - `GARBAGE_SCHEDULE_PATH`（デフォルト: `config/garbage_schedule.json`）
+- `AUTH_TOKEN`（任意。設定すると `/api/v1/*` 認証ON）
 
 ### `config/garbage_schedule.json`
 
@@ -109,6 +123,7 @@ docker compose down
 ```bash
 curl -X POST http://localhost:8080/api/v1/notes \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
   -d '{"kind":"notice","body":"牛乳を買ってください","pinned":true}'
 ```
 
@@ -124,6 +139,9 @@ curl -X POST http://localhost:8080/api/v1/notes \
 - `.env` はコミットしないでください。
 - 祝日・年末年始などの特例は MVP0 対象外です（将来対応予定）。
 - MVP0範囲外（天気/室温/株価/献立/在庫/IoT等）は実装しません。
+- 本アプリは公開前提で作っていません。ルーターのポート開放はしないでください。
+- VPN経由で使う場合は `AUTH_TOKEN` 設定を強く推奨します。
+- `admin` 系エンドポイント（`/api/v1/admin/*`）は提供していません。運用で利用しません。
 - オフライン時も UI の枠は開けますが、`/api/v1/*` のデータ更新はできません。
   オンライン復帰後は自動で再取得して通常動作に戻ります。
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@ services:
       - GARBAGE_SCHEDULE_PATH=${GARBAGE_SCHEDULE_PATH:-config/garbage_schedule.json}
       - WEB_DIST_PATH=${WEB_DIST_PATH:-web/dist}
       - CORS_ALLOW_ORIGINS=${CORS_ALLOW_ORIGINS:-}
+      - AUTH_TOKEN
     volumes:
       - ./data:/data
     restart: unless-stopped

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -66,6 +66,7 @@ func New(ctx context.Context) (*App, error) {
 		dashboardUseCase,
 		spaHandler,
 		cfg.CORSAllowOrigins,
+		cfg.AuthToken,
 	)
 	server := &http.Server{
 		Addr:              cfg.AppAddr,

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	GarbageSchedulePath string
 	WebDistPath         string
 	CORSAllowOrigins    []string
+	AuthToken           string
 }
 
 func LoadFromEnv() Config {
@@ -20,6 +21,7 @@ func LoadFromEnv() Config {
 		GarbageSchedulePath: getEnv("GARBAGE_SCHEDULE_PATH", "config/garbage_schedule.json"),
 		WebDistPath:         getEnv("WEB_DIST_PATH", "web/dist"),
 		CORSAllowOrigins:    parseCSVEnv("CORS_ALLOW_ORIGINS"),
+		AuthToken:           strings.TrimSpace(os.Getenv("AUTH_TOKEN")),
 	}
 }
 

--- a/internal/app/http/middleware.go
+++ b/internal/app/http/middleware.go
@@ -24,10 +24,46 @@ func (r *statusRecorder) WriteHeader(status int) {
 	r.ResponseWriter.WriteHeader(status)
 }
 
-func applyMiddlewares(next http.Handler, corsAllowOrigins []string) http.Handler {
-	h := corsMiddleware(next, corsAllowOrigins)
+func applyMiddlewares(next http.Handler, corsAllowOrigins []string, authToken string) http.Handler {
+	h := authTokenMiddleware(next, authToken)
+	h = corsMiddleware(h, corsAllowOrigins)
 	h = requestIDAndAccessLogMiddleware(h)
 	return h
+}
+
+func authTokenMiddleware(next http.Handler, authToken string) http.Handler {
+	if authToken == "" {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isAPIv1Path(r.URL.Path) || r.Method == http.MethodOptions {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if !isValidBearerToken(r.Header.Get("Authorization"), authToken) {
+			writeError(w, r, http.StatusUnauthorized, errorCodeUnauthorized, "authentication required")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isAPIv1Path(path string) bool {
+	return path == "/api/v1" || strings.HasPrefix(path, "/api/v1/")
+}
+
+func isValidBearerToken(authHeader string, expectedToken string) bool {
+	parts := strings.Fields(authHeader)
+	if len(parts) != 2 {
+		return false
+	}
+	if !strings.EqualFold(parts[0], "Bearer") {
+		return false
+	}
+	return parts[1] == expectedToken
 }
 
 func requestIDAndAccessLogMiddleware(next http.Handler) http.Handler {

--- a/internal/app/http/middleware_test.go
+++ b/internal/app/http/middleware_test.go
@@ -12,7 +12,7 @@ import (
 func TestErrorFormatIncludesRequestIDAndTokyoTimestamp(t *testing.T) {
 	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusBadRequest, errorCodeValidation, "invalid request")
-	}), []string{})
+	}), []string{}, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
 	rec := httptest.NewRecorder()
@@ -60,7 +60,7 @@ func TestErrorFormatIncludesRequestIDAndTokyoTimestamp(t *testing.T) {
 func TestCORSDisabledByDefault(t *testing.T) {
 	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
-	}), []string{})
+	}), []string{}, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
 	req.Header.Set("Origin", "http://localhost:5173")
@@ -75,7 +75,7 @@ func TestCORSDisabledByDefault(t *testing.T) {
 func TestCORSEnabledForConfiguredOrigin(t *testing.T) {
 	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
-	}), []string{"http://localhost:5173"})
+	}), []string{"http://localhost:5173"}, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
 	req.Header.Set("Origin", "http://localhost:5173")
@@ -93,7 +93,7 @@ func TestCORSEnabledForConfiguredOrigin(t *testing.T) {
 func TestCORSPreflightReturnsNoContent(t *testing.T) {
 	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
-	}), []string{"http://localhost:5173"})
+	}), []string{"http://localhost:5173"}, "")
 
 	req := httptest.NewRequest(http.MethodOptions, "/api/v1/notes", nil)
 	req.Header.Set("Origin", "http://localhost:5173")
@@ -105,5 +105,108 @@ func TestCORSPreflightReturnsNoContent(t *testing.T) {
 	}
 	if rec.Header().Get("X-Request-Id") == "" {
 		t.Fatal("expected X-Request-Id header for preflight request")
+	}
+}
+
+func TestCORSPreflightReturnsNoContentWhenAuthTokenEnabled(t *testing.T) {
+	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}), []string{"http://localhost:5173"}, "secret-token")
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/notes", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", rec.Code)
+	}
+}
+
+func TestAuthTokenDisabledAllowsAPIRequest(t *testing.T) {
+	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}), []string{}, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+}
+
+func TestAuthTokenRejectsMissingBearerToken(t *testing.T) {
+	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}), []string{}, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dashboard", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", rec.Code)
+	}
+
+	var payload struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+		RequestID string `json:"requestId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode json: %v", err)
+	}
+	if payload.Error.Code != errorCodeUnauthorized {
+		t.Fatalf("expected code %s, got %s", errorCodeUnauthorized, payload.Error.Code)
+	}
+	if payload.RequestID == "" {
+		t.Fatal("requestId is empty")
+	}
+}
+
+func TestAuthTokenRejectsInvalidToken(t *testing.T) {
+	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}), []string{}, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/notes", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", rec.Code)
+	}
+}
+
+func TestAuthTokenAllowsValidBearerToken(t *testing.T) {
+	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}), []string{}, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/notes", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+}
+
+func TestAuthTokenSkipsNonAPIPath(t *testing.T) {
+	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), []string{}, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
 	}
 }

--- a/internal/app/http/response.go
+++ b/internal/app/http/response.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
-	errorCodeValidation = "VALIDATION_ERROR"
-	errorCodeNotFound   = "NOT_FOUND"
-	errorCodeInternal   = "INTERNAL_ERROR"
-	errorCodeConfig     = "CONFIG_ERROR"
+	errorCodeValidation   = "VALIDATION_ERROR"
+	errorCodeNotFound     = "NOT_FOUND"
+	errorCodeUnauthorized = "UNAUTHORIZED"
+	errorCodeInternal     = "INTERNAL_ERROR"
+	errorCodeConfig       = "CONFIG_ERROR"
 )
 
 type apiErrorDetail struct {

--- a/internal/app/http/router.go
+++ b/internal/app/http/router.go
@@ -22,6 +22,7 @@ func NewRouter(
 	dashboardUseCase *usedashboard.GetDashboardUseCase,
 	spaHandler *SPAHandler,
 	corsAllowOrigins []string,
+	authToken string,
 ) http.Handler {
 	mux := http.NewServeMux()
 	healthHandler := NewHealthHandler(healthUseCase)
@@ -45,5 +46,5 @@ func NewRouter(
 
 	mux.HandleFunc("/", spaHandler.Serve)
 
-	return applyMiddlewares(mux, corsAllowOrigins)
+	return applyMiddlewares(mux, corsAllowOrigins, authToken)
 }

--- a/web/src/pages/Dashboard.vue
+++ b/web/src/pages/Dashboard.vue
@@ -71,6 +71,9 @@ function isPending(id: number): boolean {
 
 function getOperationErrorMessage(err: unknown): string {
   if (err instanceof APIError) {
+    if (err.status === 401 || err.code === 'UNAUTHORIZED') {
+      return '認証が必要です。管理者にトークン設定を確認してください。'
+    }
     if (err.code === 'NOT_FOUND') {
       return '対象が見つかりません。画面を再取得して再度お試しください。'
     }
@@ -98,6 +101,10 @@ async function loadDashboard(): Promise<void> {
   } catch (err) {
     console.error(err)
     refreshFailed.value = true
+    if (err instanceof APIError && (err.status === 401 || err.code === 'UNAUTHORIZED')) {
+      fatalError.value = '認証が必要です。Authorization: Bearer <token> を設定してください。'
+      return
+    }
     if (!dashboard.value) {
       fatalError.value = 'ダッシュボードの取得に失敗しました'
     }


### PR DESCRIPTION
## 概要
家庭内運用向けの最小セキュリティとして、`AUTH_TOKEN` による簡易トークン認証を追加しました。
`AUTH_TOKEN` 未設定時は従来どおり動作し、設定時のみ `/api/v1/*` に `Authorization: Bearer <token>` を要求します。

## 変更内容
- 認証ミドルウェア追加（サーバ）
  - `AUTH_TOKEN` 設定時のみ `/api/v1` と `/api/v1/*` を保護
  - トークン不一致/未指定は `401`（JSON統一フォーマット）
  - 401コード: `UNAUTHORIZED`
  - `OPTIONS` は通過（CORS preflight維持）
- 設定配線追加
  - `internal/app/config.Config` に `AuthToken` を追加
  - ルーターへ手動DIで渡す
- UI側の最小表示
  - APIが401の場合に「認証が必要」メッセージを表示
- 運用ドキュメント更新
  - README に「家庭内LANモード（認証なし）」と「VPN/外部アクセス想定（認証あり）」を追記
  - admin方針（`/api/v1/admin/*` は提供しない）を明記
- 環境変数更新
  - `.env.example` に `AUTH_TOKEN` を追記
  - `compose.yaml` は `AUTH_TOKEN` を空デフォルトで固定せず、環境受け取りのみ

## 受け入れ条件チェック
- `AUTH_TOKEN` 未設定: `/api/v1/health` が 200（従来どおり）
- `AUTH_TOKEN` 設定: `/api/v1/health` がトークンなし/不一致で401、一致で200
- 401レスポンスが JSON統一形式（`error/requestId/timestamp`）
- README/.env.example に運用方法を記載

## 実行確認
- `go test ./...` 成功
- `cd web && npm run build` 成功
- `docker compose up --build -d` 成功
- `AUTH_TOKEN=secret-token docker compose up --build -d` で以下確認
  - tokenなし: 401
  - `Authorization: Bearer wrong`: 401
  - `Authorization: Bearer secret-token`: 200
