### PR TITLE
運用ステータスAPIを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 APP_ADDR=:8080
+APP_VERSION=unknown
 DB_PATH=/data/app.db
 GARBAGE_SCHEDULE_PATH=config/garbage_schedule.json
 WEB_DIST_PATH=web/dist

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ docker compose up --build
 主要な環境変数:
 
 - `APP_ADDR`（デフォルト: `:8080`）
+- `APP_VERSION`（デフォルト: `unknown`）
 - `DB_PATH`（デフォルト: `/data/app.db`）
 - `GARBAGE_SCHEDULE_PATH`（デフォルト: `config/garbage_schedule.json`）
 - `BACKUP_DIR`（デフォルト: `/data/backups`）
@@ -125,6 +126,19 @@ docker compose up --build
 ### health
 
 - `GET /api/v1/health`
+
+### status（運用確認）
+
+- `GET /api/v1/status`
+
+`/api/v1/status` は Bearer 認証が必須です。
+- `AUTH_TOKEN` 設定時: `Authorization: Bearer <token>` が必要
+- `AUTH_TOKEN` 未設定時: `403`（`status endpoint requires AUTH_TOKEN`）を返します
+
+```bash
+curl http://localhost:8080/api/v1/status \
+  -H "Authorization: Bearer <token>"
+```
 
 ### dashboard
 
@@ -191,6 +205,20 @@ curl -X POST http://localhost:8080/api/v1/admin/backup \
    例: `cp ./data/backups/app-20260304-130000.db ./data/app.db`
 4. `docker compose up --build -d` で起動
 5. `GET /api/v1/health` と画面表示を確認
+
+## 困った時の確認手順
+
+まず `status` でアプリ状態を確認してください。
+
+```bash
+curl http://localhost:8080/api/v1/status \
+  -H "Authorization: Bearer <token>"
+```
+
+主な確認項目:
+- `db.ok` が `true` か
+- `config.garbageScheduleLoaded` が `true` か
+- `lastBackup` が更新されているか
 
 ## 注意事項
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,7 @@ services:
       - "8080:8080"
     environment:
       - APP_ADDR=${APP_ADDR:-:8080}
+      - APP_VERSION=${APP_VERSION:-unknown}
       - DB_PATH=${DB_PATH:-/data/app.db}
       - GARBAGE_SCHEDULE_PATH=${GARBAGE_SCHEDULE_PATH:-config/garbage_schedule.json}
       - WEB_DIST_PATH=${WEB_DIST_PATH:-web/dist}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,7 @@ COPY --from=go-builder /app/config /app/config
 COPY --from=go-builder /app/web/dist /app/web/dist
 
 ENV APP_ADDR=:8080
+ENV APP_VERSION=unknown
 ENV DB_PATH=/data/app.db
 ENV GARBAGE_SCHEDULE_PATH=config/garbage_schedule.json
 ENV WEB_DIST_PATH=web/dist

--- a/docs/API.md
+++ b/docs/API.md
@@ -35,6 +35,8 @@
 
 - `VALIDATION_ERROR`（400）
 - `NOT_FOUND`（404）
+- `UNAUTHORIZED`（401）
+- `FORBIDDEN`（403）
 - `INTERNAL_ERROR`（500）
 - `CONFIG_ERROR`（500、設定ファイル起因）
 
@@ -50,6 +52,10 @@
 ### health
 
 - `GET /api/v1/health`
+
+### status
+
+- `GET /api/v1/status`（Bearer必須）
 
 ### notes
 
@@ -94,5 +100,26 @@
       "label": "燃えるゴミ"
     }
   }
+}
+```
+
+### GET /api/v1/status
+
+```json
+{
+  "appVersion": "unknown",
+  "uptimeSeconds": 1200,
+  "serverTime": "2026-03-05T09:00:00+09:00",
+  "db": {
+    "path": "/data/app.db",
+    "ok": true
+  },
+  "config": {
+    "garbageScheduleLoaded": true
+  },
+  "auth": {
+    "enabled": true
+  },
+  "lastBackup": "2026-03-05T08:30:00+09:00"
 }
 ```

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,6 +17,7 @@ import (
 	usegarbage "github.com/na0chan-go/home-dash/internal/usecase/garbage"
 	"github.com/na0chan-go/home-dash/internal/usecase/health"
 	usenotes "github.com/na0chan-go/home-dash/internal/usecase/notes"
+	usestatus "github.com/na0chan-go/home-dash/internal/usecase/status"
 )
 
 type App struct {
@@ -46,6 +47,7 @@ func New(ctx context.Context) (*App, error) {
 	setDoneUseCase := usenotes.NewSetDoneUseCase(notesRepo)
 
 	clock := system.NewClock()
+	startedAt := clock.NowUTC()
 	healthUseCase := health.NewGetHealthUseCase(clock)
 
 	garbageProvider := infragarbage.NewJSONScheduleProvider(cfg.GarbageSchedulePath)
@@ -55,6 +57,18 @@ func New(ctx context.Context) (*App, error) {
 	dashboardUseCase := usedashboard.NewGetDashboardUseCase(notesRepo, garbageProvider, clock)
 	backupManager := db.NewSQLiteBackupManager(sqliteDB)
 	backupUseCase := usebackup.NewRunBackupUseCase(backupManager, cfg.BackupDir, cfg.BackupKeep)
+	dbChecker := db.NewSQLiteHealthChecker(sqliteDB)
+	backupStatusReader := db.NewFileBackupStatusReader(cfg.BackupDir)
+	statusUseCase := usestatus.NewGetStatusUseCase(
+		clock,
+		dbChecker,
+		garbageProvider,
+		backupStatusReader,
+		cfg.DBPath,
+		cfg.AuthToken != "",
+		cfg.AppVersion,
+		startedAt,
+	)
 	adminBackupHandler := httpapi.NewAdminBackupHandler(backupUseCase)
 	spaHandler := httpapi.NewSPAHandler(cfg.WebDistPath)
 	scheduler := newBackupScheduler(cfg.BackupInterval, backupUseCase.Execute)
@@ -70,6 +84,7 @@ func New(ctx context.Context) (*App, error) {
 		garbageTomorrowUseCase,
 		garbageSummaryUseCase,
 		dashboardUseCase,
+		statusUseCase,
 		adminBackupHandler,
 		spaHandler,
 		cfg.CORSAllowOrigins,

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -9,6 +9,7 @@ import (
 
 type Config struct {
 	AppAddr             string
+	AppVersion          string
 	DBPath              string
 	GarbageSchedulePath string
 	WebDistPath         string
@@ -22,6 +23,7 @@ type Config struct {
 func LoadFromEnv() Config {
 	return Config{
 		AppAddr:             getEnv("APP_ADDR", ":8080"),
+		AppVersion:          getEnv("APP_VERSION", "unknown"),
 		DBPath:              getEnv("DB_PATH", "/data/app.db"),
 		GarbageSchedulePath: getEnv("GARBAGE_SCHEDULE_PATH", "config/garbage_schedule.json"),
 		WebDistPath:         getEnv("WEB_DIST_PATH", "web/dist"),

--- a/internal/app/http/middleware.go
+++ b/internal/app/http/middleware.go
@@ -38,6 +38,19 @@ func authTokenMiddleware(next http.Handler, authToken string) http.Handler {
 			return
 		}
 
+		if isStatusAPIPath(r.URL.Path) {
+			if authToken == "" {
+				writeError(w, r, http.StatusForbidden, errorCodeForbidden, "status endpoint requires AUTH_TOKEN")
+				return
+			}
+			if !isValidBearerToken(r.Header.Get("Authorization"), authToken) {
+				writeError(w, r, http.StatusUnauthorized, errorCodeUnauthorized, "authentication required")
+				return
+			}
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		if isAdminAPIPath(r.URL.Path) {
 			if authToken == "" {
 				writeError(w, r, http.StatusForbidden, errorCodeForbidden, "admin endpoint requires AUTH_TOKEN")
@@ -71,6 +84,10 @@ func isAPIv1Path(path string) bool {
 
 func isAdminAPIPath(path string) bool {
 	return path == "/api/v1/admin" || strings.HasPrefix(path, "/api/v1/admin/")
+}
+
+func isStatusAPIPath(path string) bool {
+	return path == "/api/v1/status"
 }
 
 func isValidBearerToken(authHeader string, expectedToken string) bool {

--- a/internal/app/http/middleware_test.go
+++ b/internal/app/http/middleware_test.go
@@ -211,6 +211,52 @@ func TestAuthTokenSkipsNonAPIPath(t *testing.T) {
 	}
 }
 
+func TestStatusEndpointRequiresAuthTokenConfig(t *testing.T) {
+	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}), []string{}, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"FORBIDDEN"`) {
+		t.Fatalf("unexpected response body: %s", rec.Body.String())
+	}
+}
+
+func TestStatusEndpointRequiresBearerTokenWhenConfigured(t *testing.T) {
+	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}), []string{}, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", rec.Code)
+	}
+}
+
+func TestStatusEndpointAllowsValidBearerTokenWhenConfigured(t *testing.T) {
+	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}), []string{}, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+}
+
 func TestAdminEndpointRequiresAuthTokenConfig(t *testing.T) {
 	h := applyMiddlewares(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})

--- a/internal/app/http/router.go
+++ b/internal/app/http/router.go
@@ -7,6 +7,7 @@ import (
 	usegarbage "github.com/na0chan-go/home-dash/internal/usecase/garbage"
 	"github.com/na0chan-go/home-dash/internal/usecase/health"
 	usenotes "github.com/na0chan-go/home-dash/internal/usecase/notes"
+	usestatus "github.com/na0chan-go/home-dash/internal/usecase/status"
 )
 
 func NewRouter(
@@ -20,6 +21,7 @@ func NewRouter(
 	garbageTomorrowUseCase *usegarbage.GetTomorrowUseCase,
 	garbageSummaryUseCase *usegarbage.GetSummaryUseCase,
 	dashboardUseCase *usedashboard.GetDashboardUseCase,
+	statusUseCase *usestatus.GetStatusUseCase,
 	adminBackupHandler *AdminBackupHandler,
 	spaHandler *SPAHandler,
 	corsAllowOrigins []string,
@@ -30,6 +32,7 @@ func NewRouter(
 	notesHandler := NewNotesHandler(listNotesUseCase, addNoteUseCase, deleteNoteUseCase, setPinUseCase, setDoneUseCase)
 	garbageHandler := NewGarbageHandler(garbageTodayUseCase, garbageTomorrowUseCase, garbageSummaryUseCase)
 	dashboardHandler := NewDashboardHandler(dashboardUseCase)
+	statusHandler := NewStatusHandler(statusUseCase)
 
 	mux.HandleFunc("/api/v1/health", healthHandler.Get)
 	mux.HandleFunc("/api/v1/notes", notesHandler.HandleNotes)
@@ -38,6 +41,7 @@ func NewRouter(
 	mux.HandleFunc("/api/v1/garbage/tomorrow", garbageHandler.Tomorrow)
 	mux.HandleFunc("/api/v1/garbage/summary", garbageHandler.Summary)
 	mux.HandleFunc("/api/v1/dashboard", dashboardHandler.Get)
+	mux.HandleFunc("/api/v1/status", statusHandler.Get)
 	mux.HandleFunc("/api/v1/admin/backup", adminBackupHandler.Create)
 	mux.HandleFunc("/api/v1", func(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusNotFound, errorCodeNotFound, "not found")

--- a/internal/app/http/status_handler.go
+++ b/internal/app/http/status_handler.go
@@ -1,0 +1,42 @@
+package http
+
+import (
+	"log"
+	"net/http"
+
+	usestatus "github.com/na0chan-go/home-dash/internal/usecase/status"
+)
+
+type StatusHandler struct {
+	useCase *usestatus.GetStatusUseCase
+}
+
+func NewStatusHandler(useCase *usestatus.GetStatusUseCase) *StatusHandler {
+	return &StatusHandler{useCase: useCase}
+}
+
+func (h *StatusHandler) Get(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, r, http.StatusBadRequest, errorCodeValidation, "method not allowed")
+		return
+	}
+
+	result, err := h.useCase.Execute(r.Context())
+	if err != nil {
+		writeInternalError(w, r, errorCodeInternal, err)
+		return
+	}
+
+	requestID := getOrCreateRequestID(w, r)
+	if !result.DB.OK {
+		log.Printf("level=warn requestId=%s code=STATUS_DB_DEGRADED path=%s err=%s", requestID, r.URL.Path, result.DBError)
+	}
+	if !result.Config.GarbageScheduleLoaded {
+		log.Printf("level=warn requestId=%s code=STATUS_CONFIG_DEGRADED path=%s err=%s", requestID, r.URL.Path, result.ConfigError)
+	}
+	if result.LastBackupError != "" {
+		log.Printf("level=warn requestId=%s code=STATUS_BACKUP_CHECK_FAILED path=%s err=%s", requestID, r.URL.Path, result.LastBackupError)
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}

--- a/internal/app/http/status_handler_test.go
+++ b/internal/app/http/status_handler_test.go
@@ -1,0 +1,188 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	domaingarbage "github.com/na0chan-go/home-dash/internal/domain/garbage"
+	usestatus "github.com/na0chan-go/home-dash/internal/usecase/status"
+)
+
+type statusHandlerStubClock struct {
+	now time.Time
+}
+
+func (c *statusHandlerStubClock) NowUTC() time.Time {
+	return c.now
+}
+
+type statusHandlerStubDBChecker struct {
+	err error
+}
+
+func (c *statusHandlerStubDBChecker) Check(context.Context) error {
+	return c.err
+}
+
+type statusHandlerStubGarbageProvider struct {
+	err error
+}
+
+func (p *statusHandlerStubGarbageProvider) GetSchedule(context.Context) (domaingarbage.Schedule, error) {
+	if p.err != nil {
+		return domaingarbage.Schedule{}, p.err
+	}
+	return domaingarbage.Schedule{
+		Sunday:    []string{},
+		Monday:    []string{},
+		Tuesday:   []string{},
+		Wednesday: []string{},
+		Thursday:  []string{},
+		Friday:    []string{},
+		Saturday:  []string{},
+	}, nil
+}
+
+func TestStatusHandler_Get_Success(t *testing.T) {
+	now := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+	backupAt := now.Add(-time.Hour)
+	useCase := usestatus.NewGetStatusUseCase(
+		&statusHandlerStubClock{now: now},
+		&statusHandlerStubDBChecker{},
+		&statusHandlerStubGarbageProvider{},
+		&statusHandlerStubBackupReader{lastBackup: &backupAt},
+		"/data/app.db",
+		true,
+		"abc1234",
+		now.Add(-time.Minute),
+	)
+	handler := NewStatusHandler(useCase)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+
+	handler.Get(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var payload struct {
+		AppVersion    string `json:"appVersion"`
+		UptimeSeconds int64  `json:"uptimeSeconds"`
+		ServerTime    string `json:"serverTime"`
+		DB            struct {
+			Path string `json:"path"`
+			OK   bool   `json:"ok"`
+		} `json:"db"`
+		Config struct {
+			GarbageScheduleLoaded bool `json:"garbageScheduleLoaded"`
+		} `json:"config"`
+		Auth struct {
+			Enabled bool `json:"enabled"`
+		} `json:"auth"`
+		LastBackup *string `json:"lastBackup"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if payload.AppVersion != "abc1234" {
+		t.Fatalf("unexpected appVersion: %s", payload.AppVersion)
+	}
+	if payload.DB.Path != "/data/app.db" || !payload.DB.OK {
+		t.Fatalf("unexpected db payload: %+v", payload.DB)
+	}
+	if !payload.Config.GarbageScheduleLoaded {
+		t.Fatal("garbageScheduleLoaded should be true")
+	}
+	if !payload.Auth.Enabled {
+		t.Fatal("auth.enabled should be true")
+	}
+	if payload.LastBackup == nil || *payload.LastBackup == "" {
+		t.Fatal("lastBackup should be set")
+	}
+}
+
+func TestStatusHandler_Get_MethodNotAllowed(t *testing.T) {
+	now := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+	useCase := usestatus.NewGetStatusUseCase(
+		&statusHandlerStubClock{now: now},
+		&statusHandlerStubDBChecker{},
+		&statusHandlerStubGarbageProvider{},
+		&statusHandlerStubBackupReader{},
+		"/data/app.db",
+		false,
+		"unknown",
+		now,
+	)
+	handler := NewStatusHandler(useCase)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+
+	handler.Get(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestStatusHandler_Get_DegradedStillReturns200(t *testing.T) {
+	now := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+	useCase := usestatus.NewGetStatusUseCase(
+		&statusHandlerStubClock{now: now},
+		&statusHandlerStubDBChecker{err: errors.New("db down")},
+		&statusHandlerStubGarbageProvider{err: errors.New("config broken")},
+		&statusHandlerStubBackupReader{err: errors.New("backup dir unreadable")},
+		"/data/app.db",
+		true,
+		"abc1234",
+		now.Add(-time.Minute),
+	)
+	handler := NewStatusHandler(useCase)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+
+	handler.Get(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var payload struct {
+		DB struct {
+			OK bool `json:"ok"`
+		} `json:"db"`
+		Config struct {
+			GarbageScheduleLoaded bool `json:"garbageScheduleLoaded"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if payload.DB.OK {
+		t.Fatal("db.ok should be false")
+	}
+	if payload.Config.GarbageScheduleLoaded {
+		t.Fatal("garbageScheduleLoaded should be false")
+	}
+}
+
+type statusHandlerStubBackupReader struct {
+	lastBackup *time.Time
+	err        error
+}
+
+func (r *statusHandlerStubBackupReader) LastBackupAt(context.Context) (*time.Time, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.lastBackup, nil
+}

--- a/internal/infra/db/backup_status_reader.go
+++ b/internal/infra/db/backup_status_reader.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+type FileBackupStatusReader struct {
+	backupDir string
+}
+
+func NewFileBackupStatusReader(backupDir string) *FileBackupStatusReader {
+	return &FileBackupStatusReader{backupDir: backupDir}
+}
+
+func (r *FileBackupStatusReader) LastBackupAt(_ context.Context) (*time.Time, error) {
+	entries, err := os.ReadDir(r.backupDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read backup dir: %w", err)
+	}
+
+	var latest time.Time
+	found := false
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "app-") || !strings.HasSuffix(name, ".db") {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat backup file: %w", err)
+		}
+
+		modTime := info.ModTime()
+		if !found || modTime.After(latest) {
+			latest = modTime
+			found = true
+		}
+	}
+
+	if !found {
+		return nil, nil
+	}
+
+	normalized := latest.UTC()
+	return &normalized, nil
+}

--- a/internal/infra/db/backup_status_reader_test.go
+++ b/internal/infra/db/backup_status_reader_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileBackupStatusReader_LastBackupAt(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "app-20260301-010000.db")
+	newPath := filepath.Join(dir, "app-20260304-090000.db")
+	ignorePath := filepath.Join(dir, "memo.txt")
+
+	if err := os.WriteFile(oldPath, []byte("old"), 0o644); err != nil {
+		t.Fatalf("failed to write old backup file: %v", err)
+	}
+	if err := os.WriteFile(newPath, []byte("new"), 0o644); err != nil {
+		t.Fatalf("failed to write new backup file: %v", err)
+	}
+	if err := os.WriteFile(ignorePath, []byte("ignore"), 0o644); err != nil {
+		t.Fatalf("failed to write ignore file: %v", err)
+	}
+
+	oldTime := time.Date(2026, 3, 1, 1, 0, 0, 0, time.UTC)
+	newTime := time.Date(2026, 3, 4, 9, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
+		t.Fatalf("failed to chtimes old backup file: %v", err)
+	}
+	if err := os.Chtimes(newPath, newTime, newTime); err != nil {
+		t.Fatalf("failed to chtimes new backup file: %v", err)
+	}
+
+	reader := NewFileBackupStatusReader(dir)
+	got, err := reader.LastBackupAt(context.Background())
+	if err != nil {
+		t.Fatalf("LastBackupAt returned error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected latest backup time, got nil")
+	}
+	if !got.Equal(newTime) {
+		t.Fatalf("unexpected latest backup time: got=%s want=%s", got.Format(time.RFC3339), newTime.Format(time.RFC3339))
+	}
+}
+
+func TestFileBackupStatusReader_LastBackupAt_NoFile(t *testing.T) {
+	t.Parallel()
+
+	reader := NewFileBackupStatusReader(t.TempDir())
+	got, err := reader.LastBackupAt(context.Background())
+	if err != nil {
+		t.Fatalf("LastBackupAt returned error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestFileBackupStatusReader_LastBackupAt_NoDirectory(t *testing.T) {
+	t.Parallel()
+
+	reader := NewFileBackupStatusReader(filepath.Join(t.TempDir(), "missing"))
+	got, err := reader.LastBackupAt(context.Background())
+	if err != nil {
+		t.Fatalf("LastBackupAt returned error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}

--- a/internal/infra/db/health_checker.go
+++ b/internal/infra/db/health_checker.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+type SQLiteHealthChecker struct {
+	db *sql.DB
+}
+
+func NewSQLiteHealthChecker(db *sql.DB) *SQLiteHealthChecker {
+	return &SQLiteHealthChecker{db: db}
+}
+
+func (c *SQLiteHealthChecker) Check(ctx context.Context) error {
+	if err := c.db.PingContext(ctx); err != nil {
+		return fmt.Errorf("failed to ping sqlite: %w", err)
+	}
+	return nil
+}

--- a/internal/infra/db/health_checker_test.go
+++ b/internal/infra/db/health_checker_test.go
@@ -1,0 +1,38 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSQLiteHealthChecker_Check(t *testing.T) {
+	t.Parallel()
+
+	sqliteDB, err := OpenSQLite(t.TempDir() + "/app.db")
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	defer sqliteDB.Close()
+
+	checker := NewSQLiteHealthChecker(sqliteDB)
+	if err := checker.Check(context.Background()); err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+}
+
+func TestSQLiteHealthChecker_Check_ReturnsErrorAfterClose(t *testing.T) {
+	t.Parallel()
+
+	sqliteDB, err := OpenSQLite(t.TempDir() + "/app.db")
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	if err := sqliteDB.Close(); err != nil {
+		t.Fatalf("failed to close sqlite: %v", err)
+	}
+
+	checker := NewSQLiteHealthChecker(sqliteDB)
+	if err := checker.Check(context.Background()); err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}

--- a/internal/ports/backup_status_reader.go
+++ b/internal/ports/backup_status_reader.go
@@ -1,0 +1,10 @@
+package ports
+
+import (
+	"context"
+	"time"
+)
+
+type BackupStatusReader interface {
+	LastBackupAt(ctx context.Context) (*time.Time, error)
+}

--- a/internal/ports/db_health_checker.go
+++ b/internal/ports/db_health_checker.go
@@ -1,0 +1,7 @@
+package ports
+
+import "context"
+
+type DBHealthChecker interface {
+	Check(ctx context.Context) error
+}

--- a/internal/usecase/status/dto.go
+++ b/internal/usecase/status/dto.go
@@ -1,0 +1,29 @@
+package status
+
+type StatusDTO struct {
+	AppVersion             string          `json:"appVersion"`
+	UptimeSeconds          int64           `json:"uptimeSeconds"`
+	ServerTime             string          `json:"serverTime"`
+	DB                     DBStatusDTO     `json:"db"`
+	Config                 ConfigStatusDTO `json:"config"`
+	Auth                   AuthStatusDTO   `json:"auth"`
+	LastBackup             *string         `json:"lastBackup,omitempty"`
+	LastDashboardRefreshAt *string         `json:"lastDashboardRefreshAt,omitempty"`
+
+	DBError         string `json:"-"`
+	ConfigError     string `json:"-"`
+	LastBackupError string `json:"-"`
+}
+
+type DBStatusDTO struct {
+	Path string `json:"path"`
+	OK   bool   `json:"ok"`
+}
+
+type ConfigStatusDTO struct {
+	GarbageScheduleLoaded bool `json:"garbageScheduleLoaded"`
+}
+
+type AuthStatusDTO struct {
+	Enabled bool `json:"enabled"`
+}

--- a/internal/usecase/status/get_status.go
+++ b/internal/usecase/status/get_status.go
@@ -1,0 +1,114 @@
+package status
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/na0chan-go/home-dash/internal/ports"
+)
+
+const (
+	defaultAppVersion = "unknown"
+	tokyoTimezone     = "Asia/Tokyo"
+	timestampLayout   = "2006-01-02T15:04:05Z07:00"
+)
+
+type GetStatusUseCase struct {
+	clock           ports.Clock
+	dbChecker       ports.DBHealthChecker
+	garbageProvider ports.GarbageScheduleProvider
+	backupReader    ports.BackupStatusReader
+	dbPath          string
+	authEnabled     bool
+	appVersion      string
+	startedAt       time.Time
+}
+
+func NewGetStatusUseCase(
+	clock ports.Clock,
+	dbChecker ports.DBHealthChecker,
+	garbageProvider ports.GarbageScheduleProvider,
+	backupReader ports.BackupStatusReader,
+	dbPath string,
+	authEnabled bool,
+	appVersion string,
+	startedAt time.Time,
+) *GetStatusUseCase {
+	version := strings.TrimSpace(appVersion)
+	if version == "" {
+		version = defaultAppVersion
+	}
+
+	if startedAt.IsZero() {
+		startedAt = clock.NowUTC()
+	}
+
+	return &GetStatusUseCase{
+		clock:           clock,
+		dbChecker:       dbChecker,
+		garbageProvider: garbageProvider,
+		backupReader:    backupReader,
+		dbPath:          dbPath,
+		authEnabled:     authEnabled,
+		appVersion:      version,
+		startedAt:       startedAt.UTC(),
+	}
+}
+
+func (u *GetStatusUseCase) Execute(ctx context.Context) (StatusDTO, error) {
+	nowUTC := u.clock.NowUTC()
+	nowTokyo := toTokyo(nowUTC)
+	output := StatusDTO{
+		AppVersion:    u.appVersion,
+		UptimeSeconds: uptimeSeconds(nowUTC, u.startedAt),
+		ServerTime:    nowTokyo.Format(timestampLayout),
+		DB: DBStatusDTO{
+			Path: u.dbPath,
+			OK:   true,
+		},
+		Config: ConfigStatusDTO{
+			GarbageScheduleLoaded: true,
+		},
+		Auth: AuthStatusDTO{
+			Enabled: u.authEnabled,
+		},
+	}
+
+	if err := u.dbChecker.Check(ctx); err != nil {
+		output.DB.OK = false
+		output.DBError = err.Error()
+	}
+
+	if _, err := u.garbageProvider.GetSchedule(ctx); err != nil {
+		output.Config.GarbageScheduleLoaded = false
+		output.ConfigError = err.Error()
+	}
+
+	if u.backupReader != nil {
+		lastBackupAt, err := u.backupReader.LastBackupAt(ctx)
+		if err != nil {
+			output.LastBackupError = err.Error()
+		} else if lastBackupAt != nil {
+			value := lastBackupAt.In(nowTokyo.Location()).Format(timestampLayout)
+			output.LastBackup = &value
+		}
+	}
+
+	return output, nil
+}
+
+func toTokyo(ts time.Time) time.Time {
+	loc, err := time.LoadLocation(tokyoTimezone)
+	if err != nil {
+		loc = time.FixedZone("JST", 9*60*60)
+	}
+	return ts.In(loc)
+}
+
+func uptimeSeconds(nowUTC, startedAt time.Time) int64 {
+	if nowUTC.Before(startedAt) {
+		return 0
+	}
+	return int64(nowUTC.Sub(startedAt).Seconds())
+}

--- a/internal/usecase/status/get_status_test.go
+++ b/internal/usecase/status/get_status_test.go
@@ -1,0 +1,157 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	domaingarbage "github.com/na0chan-go/home-dash/internal/domain/garbage"
+	"github.com/na0chan-go/home-dash/internal/ports"
+)
+
+type stubClock struct {
+	now time.Time
+}
+
+func (c *stubClock) NowUTC() time.Time {
+	return c.now
+}
+
+type stubDBChecker struct {
+	err error
+}
+
+func (c *stubDBChecker) Check(context.Context) error {
+	return c.err
+}
+
+type stubGarbageProvider struct {
+	err error
+}
+
+func (p *stubGarbageProvider) GetSchedule(context.Context) (domaingarbage.Schedule, error) {
+	if p.err != nil {
+		return domaingarbage.Schedule{}, p.err
+	}
+	return domaingarbage.Schedule{
+		Sunday:    []string{},
+		Monday:    []string{"燃えるゴミ"},
+		Tuesday:   []string{},
+		Wednesday: []string{},
+		Thursday:  []string{},
+		Friday:    []string{},
+		Saturday:  []string{},
+	}, nil
+}
+
+type stubBackupReader struct {
+	lastBackup *time.Time
+	err        error
+}
+
+func (r *stubBackupReader) LastBackupAt(context.Context) (*time.Time, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.lastBackup, nil
+}
+
+func TestGetStatusUseCase_Execute_Success(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+	startedAt := now.Add(-10 * time.Minute)
+	lastBackup := now.Add(-30 * time.Minute)
+
+	useCase := NewGetStatusUseCase(
+		&stubClock{now: now},
+		&stubDBChecker{},
+		&stubGarbageProvider{},
+		&stubBackupReader{lastBackup: &lastBackup},
+		"/data/app.db",
+		true,
+		"abc1234",
+		startedAt,
+	)
+
+	got, err := useCase.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if got.AppVersion != "abc1234" {
+		t.Fatalf("unexpected appVersion: %s", got.AppVersion)
+	}
+	if got.UptimeSeconds != 600 {
+		t.Fatalf("unexpected uptimeSeconds: %d", got.UptimeSeconds)
+	}
+	if got.DB.Path != "/data/app.db" || !got.DB.OK {
+		t.Fatalf("unexpected db status: %+v", got.DB)
+	}
+	if !got.Config.GarbageScheduleLoaded {
+		t.Fatal("garbageScheduleLoaded should be true")
+	}
+	if !got.Auth.Enabled {
+		t.Fatal("auth.enabled should be true")
+	}
+	if got.LastBackup == nil || *got.LastBackup == "" {
+		t.Fatal("lastBackup should be set")
+	}
+	if got.DBError != "" || got.ConfigError != "" || got.LastBackupError != "" {
+		t.Fatalf("unexpected diagnostic values: %+v", got)
+	}
+	if got.ServerTime != "2026-03-05T09:00:00+09:00" {
+		t.Fatalf("unexpected serverTime: %s", got.ServerTime)
+	}
+}
+
+func TestGetStatusUseCase_Execute_Degraded(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+	useCase := NewGetStatusUseCase(
+		&stubClock{now: now},
+		&stubDBChecker{err: errors.New("db unavailable")},
+		&stubGarbageProvider{err: errors.New("broken schedule file")},
+		&stubBackupReader{err: errors.New("backup dir not readable")},
+		"/data/app.db",
+		false,
+		"",
+		now.Add(10*time.Second),
+	)
+
+	got, err := useCase.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if got.AppVersion != defaultAppVersion {
+		t.Fatalf("expected appVersion=%s, got %s", defaultAppVersion, got.AppVersion)
+	}
+	if got.UptimeSeconds != 0 {
+		t.Fatalf("expected uptimeSeconds=0, got %d", got.UptimeSeconds)
+	}
+	if got.DB.OK {
+		t.Fatal("db.ok should be false")
+	}
+	if got.Config.GarbageScheduleLoaded {
+		t.Fatal("garbageScheduleLoaded should be false")
+	}
+	if got.Auth.Enabled {
+		t.Fatal("auth.enabled should be false")
+	}
+	if got.LastBackup != nil {
+		t.Fatalf("lastBackup should be nil, got %v", *got.LastBackup)
+	}
+	if got.DBError == "" || got.ConfigError == "" || got.LastBackupError == "" {
+		t.Fatalf("expected diagnostic errors, got: %+v", got)
+	}
+}
+
+var (
+	_ ports.DBHealthChecker        = (*stubDBChecker)(nil)
+	_ ports.GarbageScheduleProvider = (*stubGarbageProvider)(nil)
+	_ ports.BackupStatusReader     = (*stubBackupReader)(nil)
+	_ ports.Clock                  = (*stubClock)(nil)
+)


### PR DESCRIPTION
## 概要

家庭内常時運用時の死活/状態確認をしやすくするため、`/api/v1/status` を追加しました。既存の `/api/v1/health` は互換性を維持したまま残しています。

## 変更点

- `/api/v1/status` を追加（Bearer必須）
- status用usecaseを追加（`appVersion`, `uptimeSeconds`, `serverTime`, `db`, `config`, `auth`, `lastBackup`）
- DB軽量ヘルスチェック（Ping）とバックアップ最終時刻取得をinfraに追加
- `AUTH_TOKEN` 未設定時の `/api/v1/status` は `403`、設定時はBearer必須（`401`）
- README / `docs/API.md` に運用確認手順を追記
- `APP_VERSION` を設定可能化（`.env.example` / `compose.yaml` / `docker/Dockerfile`）
- 関連ユニットテストを追加

## 確認手順

1. `go test ./...`
2. `cd web && npm run build`
3. `AUTH_TOKEN=secret-token docker compose up --build -d` 後、`/api/v1/status` をBearerあり/なしで確認

## 確認結果

- [x] `go test ./...` が成功する
- [x] 必要なAPIの動作確認を行った
- [x] MVP0範囲外の機能を追加していない