### PR TITLE
iPhone向けに削除確認モーダルを追加

### DIFF
--- a/web/src/components/NoticeBoard.vue
+++ b/web/src/components/NoticeBoard.vue
@@ -14,6 +14,7 @@ const body = ref('')
 const validationError = ref('')
 const actionError = ref('')
 const inputRef = ref<HTMLInputElement | null>(null)
+const deleteTarget = ref<Note | null>(null)
 
 function validate(raw: string): string {
   const normalized = raw.trim()
@@ -56,14 +57,26 @@ async function onTogglePin(note: Note): Promise<void> {
   }
 }
 
-async function onDelete(note: Note): Promise<void> {
-  if (!window.confirm('削除しますか？')) {
+function requestDelete(note: Note): void {
+  if (isPending(note.id)) {
     return
   }
+  deleteTarget.value = note
+}
 
+function cancelDelete(): void {
+  deleteTarget.value = null
+}
+
+async function confirmDelete(): Promise<void> {
+  if (!deleteTarget.value) {
+    return
+  }
+  const target = deleteTarget.value
+  deleteTarget.value = null
   actionError.value = ''
   try {
-    await props.onDeleteNote(note)
+    await props.onDeleteNote(target)
   } catch (err) {
     actionError.value = err instanceof Error ? err.message : '削除に失敗しました'
   }
@@ -94,12 +107,22 @@ async function onDelete(note: Note): Promise<void> {
         <button class="small" type="button" :disabled="isPending(note.id)" @click="onTogglePin(note)">
           {{ note.pinned ? 'ピン解除' : 'ピン' }}
         </button>
-        <button class="small danger" type="button" :disabled="isPending(note.id)" @click="onDelete(note)">
+        <button class="small danger" type="button" :disabled="isPending(note.id)" @click="requestDelete(note)">
           削除
         </button>
       </li>
     </ul>
     <p v-else class="empty">連絡はありません</p>
+
+    <div v-if="deleteTarget" class="confirm-overlay" role="dialog" aria-modal="true" aria-label="削除確認">
+      <div class="confirm-modal">
+        <p>削除しますか？</p>
+        <div class="confirm-actions">
+          <button type="button" class="small" @click="cancelDelete">キャンセル</button>
+          <button type="button" class="small danger" @click="confirmDelete">削除</button>
+        </div>
+      </div>
+    </div>
   </section>
 </template>
 
@@ -187,5 +210,33 @@ li.pinned {
 .empty {
   margin: 10px 0 0;
   color: #666;
+}
+
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  background: rgba(0, 0, 0, 0.4);
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+
+.confirm-modal {
+  width: min(360px, 100%);
+  border-radius: 12px;
+  border: 1px solid #ddd;
+  background: #fff;
+  padding: 14px;
+}
+
+.confirm-modal p {
+  margin: 0 0 12px;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 </style>

--- a/web/src/components/ShoppingList.vue
+++ b/web/src/components/ShoppingList.vue
@@ -15,6 +15,7 @@ const showDone = ref(false)
 const validationError = ref('')
 const actionError = ref('')
 const inputRef = ref<HTMLInputElement | null>(null)
+const deleteTarget = ref<Note | null>(null)
 
 const displayedItems = computed(() => {
   if (showDone.value) {
@@ -64,14 +65,26 @@ async function onToggleDone(note: Note): Promise<void> {
   }
 }
 
-async function onDelete(note: Note): Promise<void> {
-  if (!window.confirm('削除しますか？')) {
+function requestDelete(note: Note): void {
+  if (isPending(note.id)) {
     return
   }
+  deleteTarget.value = note
+}
 
+function cancelDelete(): void {
+  deleteTarget.value = null
+}
+
+async function confirmDelete(): Promise<void> {
+  if (!deleteTarget.value) {
+    return
+  }
+  const target = deleteTarget.value
+  deleteTarget.value = null
   actionError.value = ''
   try {
-    await props.onDeleteNote(note)
+    await props.onDeleteNote(target)
   } catch (err) {
     actionError.value = err instanceof Error ? err.message : '削除に失敗しました'
   }
@@ -107,12 +120,22 @@ async function onDelete(note: Note): Promise<void> {
         <button class="small" type="button" :disabled="isPending(note.id)" @click="onToggleDone(note)">
           {{ note.done ? '未完了へ' : '完了' }}
         </button>
-        <button class="small danger" type="button" :disabled="isPending(note.id)" @click="onDelete(note)">
+        <button class="small danger" type="button" :disabled="isPending(note.id)" @click="requestDelete(note)">
           削除
         </button>
       </li>
     </ul>
     <p v-else class="empty">表示する買い物メモはありません</p>
+
+    <div v-if="deleteTarget" class="confirm-overlay" role="dialog" aria-modal="true" aria-label="削除確認">
+      <div class="confirm-modal">
+        <p>削除しますか？</p>
+        <div class="confirm-actions">
+          <button type="button" class="small" @click="cancelDelete">キャンセル</button>
+          <button type="button" class="small danger" @click="confirmDelete">削除</button>
+        </div>
+      </div>
+    </div>
   </section>
 </template>
 
@@ -210,5 +233,33 @@ li.done {
 .empty {
   margin: 10px 0 0;
   color: #666;
+}
+
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  background: rgba(0, 0, 0, 0.4);
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+
+.confirm-modal {
+  width: min(360px, 100%);
+  border-radius: 12px;
+  border: 1px solid #ddd;
+  background: #fff;
+  padding: 14px;
+}
+
+.confirm-modal p {
+  margin: 0 0 12px;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 </style>


### PR DESCRIPTION
## 概要

iPhone実機で連絡/買い物の削除ができない問題に対応しました。
削除確認を `window.confirm` からアプリ内モーダルへ置き換え、iOS Safari / PWA でも確実に操作できるようにしました。

## 変更点

- `NoticeBoard` の削除確認をカスタムモーダル化
- `ShoppingList` の削除確認をカスタムモーダル化
- 削除ボタン押下 -> モーダル表示 -> 「削除」で実行 / 「キャンセル」で中止

## 確認手順

1. `cd web && npm run build`
2. HomeDashを開く
3. 連絡/買い物の「削除」を押し、確認モーダルで削除できることを確認

## 確認結果

- [x] `npm run build` が成功する
- [x] 削除確認UIが表示される
- [x] MVP0範囲外の機能追加はない
