### PR TITLE
追加ボタンの配色を改善

### DIFF
--- a/web/src/components/NoticeBoard.vue
+++ b/web/src/components/NoticeBoard.vue
@@ -159,7 +159,15 @@ button {
   border: 1px solid #bbb;
   border-radius: 8px;
   background: #f7f7f7;
+  color: #1f2937;
   font-size: 14px;
+}
+
+.composer button {
+  border-color: #1d4ed8;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 700;
 }
 
 button:disabled {

--- a/web/src/components/ShoppingList.vue
+++ b/web/src/components/ShoppingList.vue
@@ -172,7 +172,15 @@ button {
   border: 1px solid #bbb;
   border-radius: 8px;
   background: #f7f7f7;
+  color: #1f2937;
   font-size: 14px;
+}
+
+.composer button {
+  border-color: #1d4ed8;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 700;
 }
 
 button:disabled {


### PR DESCRIPTION
## 概要

iPhone実機で「追加」ボタンが白文字/白背景に見えて視認しづらい問題を修正しました。
ボタン色を明示して、デイモードでも確実に読める配色にしています。

## 変更点

- `NoticeBoard` のボタン文字色を明示（濃色）
- `ShoppingList` のボタン文字色を明示（濃色）
- 両コンポーネントの「追加」ボタンを青背景 + 白文字に統一

## 確認手順

1. `cd web && npm run build`
2. 画面を開いて連絡/買い物の「追加」ボタンの視認性を確認

## 確認結果

- [x] `npm run build` が成功する
- [x] デイモードで追加ボタン文字が視認できる
- [x] MVP0範囲外の機能追加はない
