### PR TITLE
UIスタイル定義を共通化

### DIFF
--- a/web/src/components/GarbagePanel.vue
+++ b/web/src/components/GarbagePanel.vue
@@ -8,52 +8,44 @@ defineProps<{
 </script>
 
 <template>
-  <section class="panel">
-    <h2>ゴミ</h2>
-    <div class="block">
-      <h3>今日</h3>
-      <p class="date">{{ today.date }} ({{ today.weekday }})</p>
-      <p class="label">{{ today.label }}</p>
+  <section class="hd-panel garbage-panel">
+    <h2 class="hd-panel-title">ゴミ</h2>
+    <div class="garbage-block">
+      <h3 class="garbage-subtitle">今日</h3>
+      <p class="garbage-date">{{ today.date }} ({{ today.weekday }})</p>
+      <p class="garbage-label">{{ today.label }}</p>
     </div>
-    <div class="block">
-      <h3>明日</h3>
-      <p class="date">{{ tomorrow.date }} ({{ tomorrow.weekday }})</p>
-      <p class="label">{{ tomorrow.label }}</p>
+    <div class="garbage-block">
+      <h3 class="garbage-subtitle">明日</h3>
+      <p class="garbage-date">{{ tomorrow.date }} ({{ tomorrow.weekday }})</p>
+      <p class="garbage-label">{{ tomorrow.label }}</p>
     </div>
   </section>
 </template>
 
 <style scoped>
-.panel {
-  border: 1px solid #dcdcdc;
-  border-radius: 10px;
+.garbage-panel {
   padding: 16px;
-  background: #fff;
 }
 
-h2 {
-  margin: 0 0 12px;
-  font-size: 1.1rem;
-}
-
-.block + .block {
+.garbage-block + .garbage-block {
   margin-top: 12px;
   padding-top: 12px;
   border-top: 1px dashed #ddd;
 }
 
-h3 {
+.garbage-subtitle {
   margin: 0 0 6px;
   font-size: 1rem;
 }
 
-.date {
+.garbage-date {
   margin: 0;
   color: #666;
   font-size: 0.9rem;
 }
 
-.label {
+.garbage-label {
   margin: 4px 0 0;
   font-weight: 600;
 }

--- a/web/src/components/NoticeBoard.vue
+++ b/web/src/components/NoticeBoard.vue
@@ -84,42 +84,48 @@ async function confirmDelete(): Promise<void> {
 </script>
 
 <template>
-  <section class="panel">
-    <h2>連絡</h2>
+  <section class="hd-panel notice-board">
+    <h2 class="hd-panel-title">連絡</h2>
 
-    <form class="composer" @submit.prevent="submit">
+    <form class="hd-composer" @submit.prevent="submit">
       <input
         ref="inputRef"
         v-model="body"
+        class="hd-input-text"
         type="text"
         placeholder="連絡を入力"
         maxlength="200"
         autocomplete="off"
       />
-      <button type="submit">追加</button>
+      <button type="submit" class="hd-btn hd-btn-primary">追加</button>
     </form>
-    <p v-if="validationError" class="error">{{ validationError }}</p>
-    <p v-if="actionError" class="error">{{ actionError }}</p>
+    <p v-if="validationError" class="hd-error">{{ validationError }}</p>
+    <p v-if="actionError" class="hd-error">{{ actionError }}</p>
 
-    <ul v-if="items.length > 0" class="list">
-      <li v-for="note in items" :key="note.id" :class="{ pinned: note.pinned }">
-        <span class="body">{{ note.body }}</span>
-        <button class="small" type="button" :disabled="isPending(note.id)" @click="onTogglePin(note)">
+    <ul v-if="items.length > 0" class="hd-list">
+      <li v-for="note in items" :key="note.id" :class="['hd-list-item', { 'is-pinned': note.pinned }]">
+        <span class="hd-list-body">{{ note.body }}</span>
+        <button class="hd-btn hd-btn-small" type="button" :disabled="isPending(note.id)" @click="onTogglePin(note)">
           {{ note.pinned ? 'ピン解除' : 'ピン' }}
         </button>
-        <button class="small danger" type="button" :disabled="isPending(note.id)" @click="requestDelete(note)">
+        <button
+          class="hd-btn hd-btn-small hd-btn-danger"
+          type="button"
+          :disabled="isPending(note.id)"
+          @click="requestDelete(note)"
+        >
           削除
         </button>
       </li>
     </ul>
-    <p v-else class="empty">連絡はありません</p>
+    <p v-else class="hd-empty">連絡はありません</p>
 
-    <div v-if="deleteTarget" class="confirm-overlay" role="dialog" aria-modal="true" aria-label="削除確認">
-      <div class="confirm-modal">
+    <div v-if="deleteTarget" class="hd-confirm-overlay" role="dialog" aria-modal="true" aria-label="削除確認">
+      <div class="hd-confirm-modal">
         <p>削除しますか？</p>
-        <div class="confirm-actions">
-          <button type="button" class="small" @click="cancelDelete">キャンセル</button>
-          <button type="button" class="small danger" @click="confirmDelete">削除</button>
+        <div class="hd-confirm-actions">
+          <button type="button" class="hd-btn hd-btn-small" @click="cancelDelete">キャンセル</button>
+          <button type="button" class="hd-btn hd-btn-small hd-btn-danger" @click="confirmDelete">削除</button>
         </div>
       </div>
     </div>
@@ -127,124 +133,7 @@ async function confirmDelete(): Promise<void> {
 </template>
 
 <style scoped>
-.panel {
-  border: 1px solid #dcdcdc;
-  border-radius: 10px;
-  padding: 14px;
-  background: #fff;
-}
-
-h2 {
-  margin: 0 0 10px;
-  font-size: 1.1rem;
-}
-
-.composer {
-  display: flex;
-  gap: 8px;
-}
-
-input {
-  flex: 1;
-  height: 44px;
-  padding: 0 12px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  font-size: 16px;
-}
-
-button {
-  min-height: 44px;
-  padding: 0 14px;
-  border: 1px solid #bbb;
-  border-radius: 8px;
-  background: #f7f7f7;
-  color: #1f2937;
-  font-size: 14px;
-}
-
-.composer button {
-  border-color: #1d4ed8;
-  background: #2563eb;
-  color: #fff;
-  font-weight: 700;
-}
-
-button:disabled {
-  opacity: 0.5;
-}
-
-.list {
-  margin: 10px 0 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 8px;
-}
-
-li {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  padding: 8px;
-  border-radius: 8px;
-  background: #f7f7f7;
-}
-
-li.pinned {
+.is-pinned {
   background: #fff3cd;
-}
-
-.body {
-  flex: 1;
-}
-
-.small {
-  min-height: 38px;
-  padding: 0 10px;
-  font-size: 13px;
-}
-
-.danger {
-  color: #b00020;
-}
-
-.error {
-  margin: 8px 0 0;
-  color: #b00020;
-  font-size: 0.86rem;
-}
-
-.empty {
-  margin: 10px 0 0;
-  color: #666;
-}
-
-.confirm-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 70;
-  background: rgba(0, 0, 0, 0.4);
-  display: grid;
-  place-items: center;
-  padding: 16px;
-}
-
-.confirm-modal {
-  width: min(360px, 100%);
-  border-radius: 12px;
-  border: 1px solid #ddd;
-  background: #fff;
-  padding: 14px;
-}
-
-.confirm-modal p {
-  margin: 0 0 12px;
-}
-
-.confirm-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
 }
 </style>

--- a/web/src/components/ShoppingList.vue
+++ b/web/src/components/ShoppingList.vue
@@ -92,47 +92,53 @@ async function confirmDelete(): Promise<void> {
 </script>
 
 <template>
-  <section class="panel">
-    <h2>買い物</h2>
+  <section class="hd-panel shopping-list">
+    <h2 class="hd-panel-title">買い物</h2>
 
-    <form class="composer" @submit.prevent="submit">
+    <form class="hd-composer" @submit.prevent="submit">
       <input
         ref="inputRef"
         v-model="body"
+        class="hd-input-text"
         type="text"
         placeholder="買い物メモを入力"
         maxlength="200"
         autocomplete="off"
       />
-      <button type="submit">追加</button>
+      <button type="submit" class="hd-btn hd-btn-primary">追加</button>
     </form>
-    <p v-if="validationError" class="error">{{ validationError }}</p>
-    <p v-if="actionError" class="error">{{ actionError }}</p>
+    <p v-if="validationError" class="hd-error">{{ validationError }}</p>
+    <p v-if="actionError" class="hd-error">{{ actionError }}</p>
 
-    <label class="toggle">
+    <label class="hd-toggle">
       <input v-model="showDone" type="checkbox" />
       完了も表示
     </label>
 
-    <ul v-if="displayedItems.length > 0" class="list">
-      <li v-for="note in displayedItems" :key="note.id" :class="{ done: note.done }">
-        <span class="body">{{ note.body }}</span>
-        <button class="small" type="button" :disabled="isPending(note.id)" @click="onToggleDone(note)">
+    <ul v-if="displayedItems.length > 0" class="hd-list">
+      <li v-for="note in displayedItems" :key="note.id" :class="['hd-list-item', { 'is-done': note.done }]">
+        <span class="hd-list-body">{{ note.body }}</span>
+        <button class="hd-btn hd-btn-small" type="button" :disabled="isPending(note.id)" @click="onToggleDone(note)">
           {{ note.done ? '未完了へ' : '完了' }}
         </button>
-        <button class="small danger" type="button" :disabled="isPending(note.id)" @click="requestDelete(note)">
+        <button
+          class="hd-btn hd-btn-small hd-btn-danger"
+          type="button"
+          :disabled="isPending(note.id)"
+          @click="requestDelete(note)"
+        >
           削除
         </button>
       </li>
     </ul>
-    <p v-else class="empty">表示する買い物メモはありません</p>
+    <p v-else class="hd-empty">表示する買い物メモはありません</p>
 
-    <div v-if="deleteTarget" class="confirm-overlay" role="dialog" aria-modal="true" aria-label="削除確認">
-      <div class="confirm-modal">
+    <div v-if="deleteTarget" class="hd-confirm-overlay" role="dialog" aria-modal="true" aria-label="削除確認">
+      <div class="hd-confirm-modal">
         <p>削除しますか？</p>
-        <div class="confirm-actions">
-          <button type="button" class="small" @click="cancelDelete">キャンセル</button>
-          <button type="button" class="small danger" @click="confirmDelete">削除</button>
+        <div class="hd-confirm-actions">
+          <button type="button" class="hd-btn hd-btn-small" @click="cancelDelete">キャンセル</button>
+          <button type="button" class="hd-btn hd-btn-small hd-btn-danger" @click="confirmDelete">削除</button>
         </div>
       </div>
     </div>
@@ -140,134 +146,8 @@ async function confirmDelete(): Promise<void> {
 </template>
 
 <style scoped>
-.panel {
-  border: 1px solid #dcdcdc;
-  border-radius: 10px;
-  padding: 14px;
-  background: #fff;
-}
-
-h2 {
-  margin: 0 0 10px;
-  font-size: 1.1rem;
-}
-
-.composer {
-  display: flex;
-  gap: 8px;
-}
-
-input[type='text'] {
-  flex: 1;
-  height: 44px;
-  padding: 0 12px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  font-size: 16px;
-}
-
-button {
-  min-height: 44px;
-  padding: 0 14px;
-  border: 1px solid #bbb;
-  border-radius: 8px;
-  background: #f7f7f7;
-  color: #1f2937;
-  font-size: 14px;
-}
-
-.composer button {
-  border-color: #1d4ed8;
-  background: #2563eb;
-  color: #fff;
-  font-weight: 700;
-}
-
-button:disabled {
-  opacity: 0.5;
-}
-
-.toggle {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  margin-top: 10px;
-  font-size: 0.9rem;
-  color: #444;
-}
-
-.list {
-  margin: 10px 0 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 8px;
-}
-
-li {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  padding: 8px;
-  border-radius: 8px;
-  background: #f7f7f7;
-}
-
-li.done {
+.is-done {
   color: #888;
   text-decoration: line-through;
-}
-
-.body {
-  flex: 1;
-}
-
-.small {
-  min-height: 38px;
-  padding: 0 10px;
-  font-size: 13px;
-}
-
-.danger {
-  color: #b00020;
-}
-
-.error {
-  margin: 8px 0 0;
-  color: #b00020;
-  font-size: 0.86rem;
-}
-
-.empty {
-  margin: 10px 0 0;
-  color: #666;
-}
-
-.confirm-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 70;
-  background: rgba(0, 0, 0, 0.4);
-  display: grid;
-  place-items: center;
-  padding: 16px;
-}
-
-.confirm-modal {
-  width: min(360px, 100%);
-  border-radius: 12px;
-  border: 1px solid #ddd;
-  background: #fff;
-  padding: 14px;
-}
-
-.confirm-modal p {
-  margin: 0 0 12px;
-}
-
-.confirm-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
 }
 </style>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2,6 +2,20 @@
   font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
   color: #1f1f1f;
   background: #f4f5f7;
+  --hd-color-text: #1f1f1f;
+  --hd-color-bg-page: #f4f5f7;
+  --hd-color-surface: #ffffff;
+  --hd-color-surface-muted: #f7f7f7;
+  --hd-color-border: #dcdcdc;
+  --hd-color-border-soft: #cccccc;
+  --hd-color-border-strong: #bbbbbb;
+  --hd-color-primary: #2563eb;
+  --hd-color-primary-border: #1d4ed8;
+  --hd-color-primary-text: #ffffff;
+  --hd-color-danger: #b00020;
+  --hd-color-muted: #666666;
+  --hd-radius-panel: 10px;
+  --hd-radius-control: 8px;
 }
 
 * {
@@ -17,4 +31,130 @@ body {
 button,
 input {
   font: inherit;
+}
+
+.hd-panel {
+  border: 1px solid var(--hd-color-border);
+  border-radius: var(--hd-radius-panel);
+  padding: 14px;
+  background: var(--hd-color-surface);
+}
+
+.hd-panel-title {
+  margin: 0 0 10px;
+  font-size: 1.1rem;
+}
+
+.hd-composer {
+  display: flex;
+  gap: 8px;
+}
+
+.hd-input-text {
+  flex: 1;
+  height: 44px;
+  padding: 0 12px;
+  border: 1px solid var(--hd-color-border-soft);
+  border-radius: var(--hd-radius-control);
+  font-size: 16px;
+}
+
+.hd-btn {
+  min-height: 44px;
+  padding: 0 14px;
+  border: 1px solid var(--hd-color-border-strong);
+  border-radius: var(--hd-radius-control);
+  background: var(--hd-color-surface-muted);
+  color: var(--hd-color-text);
+  font-size: 14px;
+}
+
+.hd-btn-primary {
+  border-color: var(--hd-color-primary-border);
+  background: var(--hd-color-primary);
+  color: var(--hd-color-primary-text);
+  font-weight: 700;
+}
+
+.hd-btn-small {
+  min-height: 38px;
+  padding: 0 10px;
+  font-size: 13px;
+}
+
+.hd-btn-danger {
+  color: var(--hd-color-danger);
+}
+
+.hd-btn:disabled {
+  opacity: 0.5;
+}
+
+.hd-error {
+  margin: 8px 0 0;
+  color: var(--hd-color-danger);
+  font-size: 0.86rem;
+}
+
+.hd-empty {
+  margin: 10px 0 0;
+  color: var(--hd-color-muted);
+}
+
+.hd-list {
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.hd-list-item {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  border-radius: var(--hd-radius-control);
+  background: var(--hd-color-surface-muted);
+}
+
+.hd-list-body {
+  flex: 1;
+}
+
+.hd-toggle {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  margin-top: 10px;
+  font-size: 0.9rem;
+  color: #444444;
+}
+
+.hd-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  background: rgba(0, 0, 0, 0.4);
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+
+.hd-confirm-modal {
+  width: min(360px, 100%);
+  border-radius: 12px;
+  border: 1px solid #dddddd;
+  background: var(--hd-color-surface);
+  padding: 14px;
+}
+
+.hd-confirm-modal p {
+  margin: 0 0 12px;
+}
+
+.hd-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }


### PR DESCRIPTION
## 概要
Issue #27 に対応し、重複していたUIスタイル定義を共通CSS変数/共通クラスへ集約しました。

## 変更点
- `web/src/style.css` に共通デザイントークン（CSS変数）を追加
- `NoticeBoard` と `ShoppingList` の重複スタイルを共通クラス（`hd-*`）へ置き換え
- `GarbagePanel` も共通パネルスタイルを利用するように変更
- コンポーネント内スタイルは状態差分（`is-pinned` / `is-done` など）だけに縮小

## 動作確認
- `npm --prefix web run build` が成功

## 影響範囲
- フロントエンドの見た目定義のみ（API/サーバ処理の変更なし）

Closes #27