### PR TITLE
UIの見た目をリッチ化

### DIFF
--- a/web/src/components/GarbagePanel.vue
+++ b/web/src/components/GarbagePanel.vue
@@ -28,25 +28,34 @@ defineProps<{
   padding: 16px;
 }
 
+.garbage-block {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid #dce5f4;
+  background: linear-gradient(180deg, #ffffff 0%, #f5f8fc 100%);
+}
+
 .garbage-block + .garbage-block {
   margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px dashed #ddd;
 }
 
 .garbage-subtitle {
   margin: 0 0 6px;
-  font-size: 1rem;
+  color: #2e3a57;
+  font-size: 1.04rem;
 }
 
 .garbage-date {
   margin: 0;
-  color: #666;
+  color: #65748f;
   font-size: 0.9rem;
 }
 
 .garbage-label {
-  margin: 4px 0 0;
-  font-weight: 600;
+  margin: 8px 0 0;
+  color: #1e2a45;
+  font-size: 1.32rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
 }
 </style>

--- a/web/src/components/NoticeBoard.vue
+++ b/web/src/components/NoticeBoard.vue
@@ -134,6 +134,8 @@ async function confirmDelete(): Promise<void> {
 
 <style scoped>
 .is-pinned {
-  background: #fff3cd;
+  border-color: #ead59a;
+  background: linear-gradient(180deg, #fff8df 0%, #fff1c8 100%);
+  box-shadow: inset 4px 0 0 #e6bb40;
 }
 </style>

--- a/web/src/components/ShoppingList.vue
+++ b/web/src/components/ShoppingList.vue
@@ -147,7 +147,9 @@ async function confirmDelete(): Promise<void> {
 
 <style scoped>
 .is-done {
-  color: #888;
+  color: #7b8598;
+  border-color: #d6deeb;
+  background: linear-gradient(180deg, #f9fbfe 0%, #f0f3f9 100%);
   text-decoration: line-through;
 }
 </style>

--- a/web/src/pages/Dashboard.vue
+++ b/web/src/pages/Dashboard.vue
@@ -537,16 +537,19 @@ onUnmounted(() => {
 <template>
   <main class="page">
     <header class="header">
-      <h1>HomeDash</h1>
+      <div class="brand">
+        <h1 class="title">HomeDash</h1>
+        <p class="tagline">家庭ホワイトボード</p>
+      </div>
       <div class="status">
-        <span>更新: {{ lastUpdatedLabel }}</span>
-        <span v-if="refreshFailed" class="status-error">更新失敗</span>
-        <span v-if="isOffline" class="status-offline">オフライン</span>
+        <span class="status-chip">更新: {{ lastUpdatedLabel }}</span>
+        <span v-if="refreshFailed" class="status-chip status-error">更新失敗</span>
+        <span v-if="isOffline" class="status-chip status-offline">オフライン</span>
       </div>
     </header>
 
-    <p v-if="loading">読み込み中...</p>
-    <p v-else-if="!dashboard && fatalError">{{ fatalError }}</p>
+    <p v-if="loading" class="page-message">読み込み中...</p>
+    <p v-else-if="!dashboard && fatalError" class="page-message page-message-error">{{ fatalError }}</p>
 
     <p v-if="operationError" class="operation-error">{{ operationError }}</p>
 
@@ -587,61 +590,137 @@ onUnmounted(() => {
 
 <style scoped>
 .page {
-  max-width: 1200px;
+  position: relative;
+  max-width: 1260px;
   margin: 0 auto;
-  padding: 16px;
+  padding: 20px;
+}
+
+.page::before,
+.page::after {
+  content: '';
+  position: absolute;
+  border-radius: 999px;
+  pointer-events: none;
+  z-index: -1;
+  filter: blur(42px);
+}
+
+.page::before {
+  width: 320px;
+  height: 180px;
+  top: -36px;
+  left: -40px;
+  background: rgba(106, 146, 255, 0.24);
+}
+
+.page::after {
+  width: 260px;
+  height: 160px;
+  top: -18px;
+  right: 6px;
+  background: rgba(255, 186, 133, 0.2);
 }
 
 .header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: 12px;
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 
-h1 {
+.brand {
+  display: grid;
+  gap: 4px;
+}
+
+.title {
   margin: 0;
-  font-size: 1.8rem;
+  font-size: clamp(2rem, 3.3vw, 2.6rem);
+  letter-spacing: 0.01em;
+}
+
+.tagline {
+  margin: 0;
+  color: #68738a;
+  font-size: 0.95rem;
+  font-weight: 600;
 }
 
 .status {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 8px;
-  color: #666;
-  font-size: 0.86rem;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid #d7e1f3;
+  background: rgba(255, 255, 255, 0.85);
+  color: #4f5f7f;
+  font-size: 0.84rem;
+  font-weight: 700;
+  box-shadow: 0 6px 16px rgba(23, 43, 81, 0.08);
 }
 
 .status-error {
-  color: #b00020;
-  font-weight: 700;
+  border-color: #efc2ca;
+  background: #fff1f3;
+  color: #9e2632;
 }
 
 .status-offline {
-  color: #0b5fa8;
+  border-color: #c5dbf6;
+  background: #edf6ff;
+  color: #1f5f95;
+}
+
+.page-message {
+  margin: 0 0 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #d6dff0;
+  background: rgba(255, 255, 255, 0.8);
+  color: #51617f;
+  font-size: 0.92rem;
   font-weight: 700;
+}
+
+.page-message-error {
+  border-color: #efc2ca;
+  background: #fff4f6;
+  color: #8c1d28;
 }
 
 .operation-error {
   margin: 0 0 12px;
-  padding: 8px 10px;
-  border-radius: 8px;
-  background: #ffe8e8;
-  color: #7a0000;
+  padding: 11px 12px;
+  border-radius: 12px;
+  border: 1px solid #efc1c8;
+  background: linear-gradient(180deg, #fff5f6 0%, #ffecee 100%);
+  color: #8b1f2b;
   font-size: 0.9rem;
+  font-weight: 700;
+  box-shadow: 0 8px 18px rgba(164, 40, 51, 0.08);
 }
 
 .grid {
   display: grid;
-  gap: 12px;
+  align-items: start;
+  gap: 14px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .night-dim {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.36);
+  background: rgba(5, 9, 20, 0.38);
   pointer-events: none;
   z-index: 30;
 }
@@ -681,6 +760,10 @@ h1 {
   .header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .status {
+    justify-content: flex-start;
   }
 
   .grid {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1,21 +1,26 @@
 :root {
-  font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
-  color: #1f1f1f;
-  background: #f4f5f7;
-  --hd-color-text: #1f1f1f;
-  --hd-color-bg-page: #f4f5f7;
+  font-family: "Avenir Next", "Hiragino Sans", "Yu Gothic UI", "Yu Gothic", sans-serif;
+  color: #1f2533;
+  background: #eceff5;
+  --hd-color-text: #1f2533;
+  --hd-color-bg-page: #eceff5;
   --hd-color-surface: #ffffff;
-  --hd-color-surface-muted: #f7f7f7;
-  --hd-color-border: #dcdcdc;
-  --hd-color-border-soft: #cccccc;
-  --hd-color-border-strong: #bbbbbb;
-  --hd-color-primary: #2563eb;
-  --hd-color-primary-border: #1d4ed8;
+  --hd-color-surface-muted: #f4f7fb;
+  --hd-color-surface-hover: #eef2f8;
+  --hd-color-border: #d3dced;
+  --hd-color-border-soft: #c4cee0;
+  --hd-color-border-strong: #b1bdd2;
+  --hd-color-primary: #2f6ce5;
+  --hd-color-primary-border: #2559c0;
   --hd-color-primary-text: #ffffff;
-  --hd-color-danger: #b00020;
-  --hd-color-muted: #666666;
-  --hd-radius-panel: 10px;
-  --hd-radius-control: 8px;
+  --hd-color-danger: #b63a45;
+  --hd-color-muted: #64708a;
+  --hd-color-focus: rgba(47, 108, 229, 0.25);
+  --hd-radius-panel: 16px;
+  --hd-radius-control: 12px;
+  --hd-shadow-panel: 0 12px 28px rgba(34, 54, 98, 0.08);
+  --hd-shadow-float: 0 8px 18px rgba(30, 50, 90, 0.12);
+  --hd-transition-fast: 140ms ease;
 }
 
 * {
@@ -24,6 +29,13 @@
 
 body {
   margin: 0;
+  min-height: 100vh;
+  overflow-x: hidden;
+  color: var(--hd-color-text);
+  background:
+    radial-gradient(1200px 560px at -12% -18%, rgba(163, 194, 255, 0.42) 0%, rgba(163, 194, 255, 0) 60%),
+    radial-gradient(1000px 440px at 112% -14%, rgba(255, 208, 173, 0.36) 0%, rgba(255, 208, 173, 0) 56%),
+    var(--hd-color-bg-page);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -36,125 +48,201 @@ input {
 .hd-panel {
   border: 1px solid var(--hd-color-border);
   border-radius: var(--hd-radius-panel);
-  padding: 14px;
-  background: var(--hd-color-surface);
+  padding: 16px;
+  background: linear-gradient(180deg, #ffffff 0%, #fbfdff 100%);
+  box-shadow: var(--hd-shadow-panel);
+  backdrop-filter: blur(2px);
+  animation: hd-fade-up 220ms ease;
 }
 
 .hd-panel-title {
-  margin: 0 0 10px;
-  font-size: 1.1rem;
+  margin: 0 0 12px;
+  font-size: 1.22rem;
+  letter-spacing: 0.02em;
 }
 
 .hd-composer {
   display: flex;
-  gap: 8px;
+  gap: 10px;
 }
 
 .hd-input-text {
   flex: 1;
-  height: 44px;
-  padding: 0 12px;
+  height: 46px;
+  padding: 0 14px;
   border: 1px solid var(--hd-color-border-soft);
   border-radius: var(--hd-radius-control);
-  font-size: 16px;
+  background: #ffffff;
+  font-size: 1rem;
+  transition:
+    border-color var(--hd-transition-fast),
+    box-shadow var(--hd-transition-fast);
+}
+
+.hd-input-text:focus-visible {
+  outline: none;
+  border-color: var(--hd-color-primary);
+  box-shadow: 0 0 0 4px var(--hd-color-focus);
 }
 
 .hd-btn {
-  min-height: 44px;
-  padding: 0 14px;
+  min-height: 46px;
+  padding: 0 15px;
   border: 1px solid var(--hd-color-border-strong);
   border-radius: var(--hd-radius-control);
-  background: var(--hd-color-surface-muted);
+  background: linear-gradient(180deg, #ffffff 0%, var(--hd-color-surface-muted) 100%);
   color: var(--hd-color-text);
-  font-size: 14px;
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    transform var(--hd-transition-fast),
+    box-shadow var(--hd-transition-fast),
+    border-color var(--hd-transition-fast),
+    background var(--hd-transition-fast);
+}
+
+@media (hover: hover) {
+  .hd-btn:hover {
+    border-color: var(--hd-color-primary-border);
+    box-shadow: var(--hd-shadow-float);
+    transform: translateY(-1px);
+  }
+}
+
+.hd-btn:active {
+  transform: translateY(0);
 }
 
 .hd-btn-primary {
   border-color: var(--hd-color-primary-border);
-  background: var(--hd-color-primary);
+  background: linear-gradient(160deg, #3f7af3 0%, var(--hd-color-primary) 68%);
   color: var(--hd-color-primary-text);
-  font-weight: 700;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
 .hd-btn-small {
-  min-height: 38px;
-  padding: 0 10px;
-  font-size: 13px;
+  min-height: 40px;
+  padding: 0 12px;
+  font-size: 0.88rem;
 }
 
 .hd-btn-danger {
   color: var(--hd-color-danger);
+  border-color: rgba(182, 58, 69, 0.34);
+  background: linear-gradient(180deg, #fff7f7 0%, #fff1f2 100%);
 }
 
 .hd-btn:disabled {
-  opacity: 0.5;
+  opacity: 0.52;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
 .hd-error {
-  margin: 8px 0 0;
+  margin: 9px 0 0;
   color: var(--hd-color-danger);
-  font-size: 0.86rem;
+  font-size: 0.87rem;
+  font-weight: 600;
 }
 
 .hd-empty {
-  margin: 10px 0 0;
+  margin: 12px 0 0;
   color: var(--hd-color-muted);
+  font-size: 0.92rem;
 }
 
 .hd-list {
-  margin: 10px 0 0;
+  margin: 12px 0 0;
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 8px;
+  gap: 10px;
 }
 
 .hd-list-item {
   display: flex;
-  gap: 8px;
+  gap: 10px;
   align-items: center;
-  padding: 8px;
+  padding: 10px;
   border-radius: var(--hd-radius-control);
-  background: var(--hd-color-surface-muted);
+  border: 1px solid #e4ebf7;
+  background: linear-gradient(180deg, #ffffff 0%, #f5f8fc 100%);
+  transition:
+    transform var(--hd-transition-fast),
+    background var(--hd-transition-fast),
+    border-color var(--hd-transition-fast);
+}
+
+@media (hover: hover) {
+  .hd-list-item:hover {
+    transform: translateY(-1px);
+    background: linear-gradient(180deg, #ffffff 0%, var(--hd-color-surface-hover) 100%);
+    border-color: #d4def0;
+  }
 }
 
 .hd-list-body {
   flex: 1;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .hd-toggle {
   display: inline-flex;
-  gap: 6px;
+  gap: 7px;
   align-items: center;
-  margin-top: 10px;
-  font-size: 0.9rem;
-  color: #444444;
+  margin-top: 12px;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #4d5a75;
+}
+
+.hd-toggle input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--hd-color-primary);
 }
 
 .hd-confirm-overlay {
   position: fixed;
   inset: 0;
   z-index: 70;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(10, 16, 32, 0.44);
   display: grid;
   place-items: center;
   padding: 16px;
+  backdrop-filter: blur(2px);
 }
 
 .hd-confirm-modal {
   width: min(360px, 100%);
-  border-radius: 12px;
-  border: 1px solid #dddddd;
+  border-radius: 16px;
+  border: 1px solid #d6deef;
   background: var(--hd-color-surface);
-  padding: 14px;
+  box-shadow: 0 22px 42px rgba(13, 24, 48, 0.28);
+  padding: 16px;
 }
 
 .hd-confirm-modal p {
   margin: 0 0 12px;
+  font-weight: 600;
 }
 
 .hd-confirm-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 10px;
+}
+
+@keyframes hd-fade-up {
+  0% {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }


### PR DESCRIPTION
## 概要
Issue #23 対応として、機能追加なしでダッシュボードUIの見た目をリッチ化しました。

## 変更点
- `web/src/style.css`
  - 共通カラートークンを再設計
  - 背景グラデーション、カードの陰影、入力/ボタンのフォーカス・ホバー表現を追加
  - 共通コンポーネント (`hd-*`) の余白・角丸・視認性を改善
- `web/src/pages/Dashboard.vue`
  - ヘッダーを「タイトル + サブタイトル + ステータスチップ」構成に変更
  - 読み込み/エラーメッセージの表示を見やすく調整
  - 3カラムのレイアウト質感を改善（モバイル縦積みは維持）
- `NoticeBoard` / `ShoppingList` / `GarbagePanel`
  - pinned/done状態の視覚差分を強化
  - ゴミ表示ブロックの視認性を改善

## 動作確認
- `npm --prefix web run build` が成功

## 影響範囲
- フロントエンドの見た目のみ（API仕様・機能ロジック変更なし）

Closes #23
