### PR TITLE
楽観的UI操作の競合を抑制

### DIFF
--- a/web/src/pages/Dashboard.vue
+++ b/web/src/pages/Dashboard.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, onUnmounted, ref, toRaw } from 'vue'
 import NoticeBoard from '../components/NoticeBoard.vue'
 import ShoppingList from '../components/ShoppingList.vue'
 import GarbagePanel from '../components/GarbagePanel.vue'
+import { createAsyncQueue } from '../utils/asyncQueue'
 import {
   APIError,
   createNote,
@@ -59,6 +60,8 @@ let nightTimer: number | undefined
 let inactivityTimer: number | undefined
 let screenSaverClockTimer: number | undefined
 let tempIDSeed = -1
+// Run note mutations one-by-one to avoid optimistic rollback collisions.
+const enqueueNoteOperation = createAsyncQueue()
 
 function parseHourMinute(raw: string, fallbackMinutes: number): number {
   const normalized = raw.trim()
@@ -283,27 +286,29 @@ function cloneDashboardState(state: DashboardResponse): DashboardResponse {
 }
 
 async function withOptimisticUpdate(apply: (state: DashboardResponse) => void, commit: () => Promise<void>): Promise<void> {
-  const state = dashboard.value
-  if (!state) {
-    throw new Error('dashboard state not loaded')
-  }
+  return enqueueNoteOperation(async () => {
+    const state = dashboard.value
+    if (!state) {
+      throw new Error('dashboard state not loaded')
+    }
 
-  operationError.value = ''
-  const snapshot = cloneDashboardState(toRaw(state) as DashboardResponse)
-  apply(state)
+    operationError.value = ''
+    const snapshot = cloneDashboardState(toRaw(state) as DashboardResponse)
+    apply(state)
 
-  try {
-    await commit()
-    refreshFailed.value = false
-    lastUpdatedAt.value = new Date()
-  } catch (err) {
-    console.error(err)
-    dashboard.value = snapshot
-    refreshFailed.value = true
-    const message = getOperationErrorMessage(err)
-    operationError.value = message
-    throw new Error(message)
-  }
+    try {
+      await commit()
+      refreshFailed.value = false
+      lastUpdatedAt.value = new Date()
+    } catch (err) {
+      console.error(err)
+      dashboard.value = snapshot
+      refreshFailed.value = true
+      const message = getOperationErrorMessage(err)
+      operationError.value = message
+      throw new Error(message)
+    }
+  })
 }
 
 async function handleAddNote(kind: NoteKind, body: string): Promise<void> {

--- a/web/src/utils/asyncQueue.ts
+++ b/web/src/utils/asyncQueue.ts
@@ -1,0 +1,17 @@
+export type AsyncTask<T> = () => Promise<T>
+
+export function createAsyncQueue(): <T>(task: AsyncTask<T>) => Promise<T> {
+  let tail: Promise<void> = Promise.resolve()
+
+  return async function enqueue<T>(task: AsyncTask<T>): Promise<T> {
+    const run = tail.then(task)
+
+    // Keep the chain alive even when a task fails.
+    tail = run.then(
+      () => undefined,
+      () => undefined
+    )
+
+    return run
+  }
+}

--- a/web/tests/utils/asyncQueue.spec.ts
+++ b/web/tests/utils/asyncQueue.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { createAsyncQueue } from '../../src/utils/asyncQueue'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+describe('createAsyncQueue', () => {
+  it('タスクを順番に実行する', async () => {
+    const enqueue = createAsyncQueue()
+    const timeline: string[] = []
+
+    const first = enqueue(async () => {
+      timeline.push('first:start')
+      await sleep(30)
+      timeline.push('first:end')
+      return 'first'
+    })
+
+    const second = enqueue(async () => {
+      timeline.push('second:start')
+      timeline.push('second:end')
+      return 'second'
+    })
+
+    await expect(first).resolves.toBe('first')
+    await expect(second).resolves.toBe('second')
+    expect(timeline).toEqual(['first:start', 'first:end', 'second:start', 'second:end'])
+  })
+
+  it('途中で失敗しても後続タスクを実行する', async () => {
+    const enqueue = createAsyncQueue()
+    const timeline: string[] = []
+
+    const failed = enqueue(async () => {
+      timeline.push('failed:start')
+      throw new Error('boom')
+    })
+
+    const after = enqueue(async () => {
+      timeline.push('after:start')
+      timeline.push('after:end')
+      return 1
+    })
+
+    await expect(failed).rejects.toThrow('boom')
+    await expect(after).resolves.toBe(1)
+    expect(timeline).toEqual(['failed:start', 'after:start', 'after:end'])
+  })
+})


### PR DESCRIPTION
## 概要
Issue #25 対応として、楽観的UI操作の同時実行競合を減らすために、ノート更新処理を逐次実行に変更しました。

## 変更点
- `web/src/utils/asyncQueue.ts` を追加
  - 非同期タスクを1件ずつ順番に処理するキュー
  - 途中で失敗しても後続を処理できる実装
- `web/src/pages/Dashboard.vue`
  - `withOptimisticUpdate` をキュー経由で実行するよう変更
  - ノートの追加/ピン切替/完了切替/削除を同時実行しないよう統一
- `web/tests/utils/asyncQueue.spec.ts` を追加
  - 順次実行されること
  - 失敗後も後続タスクが実行されること

## 動作確認
- `npm --prefix web run test:run`
- `npm --prefix web run build`

## 影響範囲
- フロントの楽観的更新制御のみ（API仕様・レスポンス形式変更なし）

Closes #25
