### PR TITLE
SECURITYポリシーと最小CIを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  go:
+    name: Go Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Go Vet
+        run: go vet ./...
+
+      - name: Go Test
+        run: go test ./...
+
+      - name: Go Build
+        run: go build ./...
+
+  frontend:
+    name: Frontend Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: NPM Install
+        run: npm install
+
+      - name: Vue Build
+        run: npm run build
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker Build
+        run: docker build -f docker/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -319,6 +319,17 @@ curl http://localhost:8080/api/v1/status \
 - オフライン時も UI の枠は開けますが、`/api/v1/*` のデータ更新はできません。
   オンライン復帰後は自動で再取得して通常動作に戻ります。
 
+## Development
+
+### CI
+
+GitHub Actions で以下をチェックします。
+
+- Go build
+- Go test
+- Vue build
+- Docker build
+
 ## 開発/運用
 
 - 開発ルール: `AGENT.md`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+HomeDash は家庭内LAN利用を想定したアプリです。  
+インターネット公開用途では設計されていません。
+
+## Supported Versions
+
+現在サポート対象は `v0.x` 系列のみです。
+
+## Security Recommendations
+
+安全運用のため、以下を推奨します。
+
+- 外部公開しない
+- VPN利用時は `AUTH_TOKEN` を設定する
+- ポートフォワーディングを行わない
+- リバースプロキシ公開は非推奨
+
+## Reporting a Vulnerability
+
+脆弱性を発見した場合は、次の手順で報告してください。
+
+- 公開Issueではなくメンテナへ連絡する
+- 公開Issueに詳細を書かない
+- 修正後に公開する
+
+連絡先が未整備の場合は、GitHub Issue に `Security report` として最小情報のみ記載してください。


### PR DESCRIPTION
## 概要
Codex命令18に対応し、Public OSS向けの最低限のセキュリティ方針とCIを追加しました。

## 変更点
- ルートに `SECURITY.md` を追加
  - HomeDashは家庭LAN用途であり、インターネット公開前提ではないことを明記
  - `v0.x` サポート方針を記載
  - 推奨運用（外部公開しない、VPN時はAUTH_TOKEN、ポートフォワーディング禁止など）を記載
  - 脆弱性報告フローを記載
- `.github/workflows/ci.yml` を追加
  - トリガー: `push` / `pull_request`（`main`）
  - Go: `go vet`, `go test ./...`, `go build ./...`
  - Frontend: `npm install`, `npm run build`（`web/`）
  - Docker: `docker build -f docker/Dockerfile .`
- `README.md` に `Development` セクションを追加
  - CIで確認する項目（Go build/test, Vue build, Docker build）を追記

## 動作確認
ローカルで以下を実行し、すべて成功を確認しました。

```bash
go vet ./...
go test ./...
go build ./...
npm --prefix web install
npm --prefix web run build
docker build -f docker/Dockerfile .
```

## 影響範囲
- ドキュメントとCI設定のみ
- MVP0機能実装には変更なし
