### PR TITLE
買い物メモの入力補助を追加

### DIFF
--- a/web/src/components/ShoppingList.vue
+++ b/web/src/components/ShoppingList.vue
@@ -2,6 +2,8 @@
 import { computed, nextTick, ref } from 'vue'
 import type { Note } from '../api/client'
 
+const fixedSuggestions = ['牛乳', '卵', 'パン', 'ティッシュ', 'トイレットペーパー'] as const
+
 const props = defineProps<{
   items: Note[]
   pendingIds: number[]
@@ -24,6 +26,23 @@ const displayedItems = computed(() => {
   return props.items.filter((note) => !note.done)
 })
 
+const recentSuggestions = computed(() => {
+  const seen = new Set<string>()
+  const recent = [...props.items]
+    .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
+    .map((note) => note.body.trim())
+    .filter((body) => body !== '')
+    .filter((body) => {
+      if (seen.has(body)) {
+        return false
+      }
+      seen.add(body)
+      return true
+    })
+
+  return recent.slice(0, 5)
+})
+
 function validate(raw: string): string {
   const normalized = raw.trim()
   if (normalized === '') {
@@ -40,14 +59,22 @@ function isPending(id: number): boolean {
 }
 
 async function submit(): Promise<void> {
-  validationError.value = validate(body.value)
+  await submitBody(body.value)
+}
+
+async function submitSuggestion(suggestion: string): Promise<void> {
+  await submitBody(suggestion)
+}
+
+async function submitBody(raw: string): Promise<void> {
   actionError.value = ''
+  validationError.value = validate(raw)
   if (validationError.value !== '') {
     return
   }
 
   try {
-    await props.onAdd(body.value.trim())
+    await props.onAdd(raw.trim())
     body.value = ''
     await nextTick()
     inputRef.value?.focus()
@@ -110,6 +137,37 @@ async function confirmDelete(): Promise<void> {
     <p v-if="validationError" class="hd-error">{{ validationError }}</p>
     <p v-if="actionError" class="hd-error">{{ actionError }}</p>
 
+    <div class="shopping-suggestions">
+      <div class="shopping-suggestion-section">
+        <p class="shopping-suggestion-title">よく使う項目</p>
+        <div class="shopping-suggestion-list">
+          <button
+            v-for="suggestion in fixedSuggestions"
+            :key="suggestion"
+            type="button"
+            class="shopping-suggestion-chip"
+            @click="submitSuggestion(suggestion)"
+          >
+            {{ suggestion }}
+          </button>
+        </div>
+      </div>
+      <div v-if="recentSuggestions.length > 0" class="shopping-suggestion-section">
+        <p class="shopping-suggestion-title">最近追加した項目</p>
+        <div class="shopping-suggestion-list">
+          <button
+            v-for="suggestion in recentSuggestions"
+            :key="suggestion"
+            type="button"
+            class="shopping-suggestion-chip shopping-suggestion-chip-secondary"
+            @click="submitSuggestion(suggestion)"
+          >
+            {{ suggestion }}
+          </button>
+        </div>
+      </div>
+    </div>
+
     <label class="hd-toggle">
       <input v-model="showDone" type="checkbox" />
       完了も表示
@@ -151,5 +209,46 @@ async function confirmDelete(): Promise<void> {
   border-color: #d6deeb;
   background: #f3f6fb;
   text-decoration: line-through;
+}
+
+.shopping-suggestions {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.shopping-suggestion-section {
+  display: grid;
+  gap: 8px;
+}
+
+.shopping-suggestion-title {
+  margin: 0;
+  color: #5b6784;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.shopping-suggestion-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.shopping-suggestion-chip {
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid #c9d6ed;
+  border-radius: 999px;
+  background: #eef4ff;
+  color: #2c5db9;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.shopping-suggestion-chip-secondary {
+  background: #f6f8fc;
+  color: #52617d;
 }
 </style>

--- a/web/tests/components/ShoppingList.spec.ts
+++ b/web/tests/components/ShoppingList.spec.ts
@@ -47,6 +47,27 @@ describe('ShoppingList', () => {
     expect((input.element as HTMLInputElement).value).toBe('')
   })
 
+  it('固定候補を押すとそのまま追加できる', async () => {
+    const onAdd = vi.fn().mockResolvedValue(undefined)
+    const wrapper = mount(ShoppingList, {
+      props: {
+        items: [],
+        pendingIds: [],
+        onAdd,
+        onToggleDone: vi.fn().mockResolvedValue(undefined),
+        onDeleteNote: vi.fn().mockResolvedValue(undefined)
+      }
+    })
+
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text() === '牛乳')!
+      .trigger('click')
+    await flushPromises()
+
+    expect(onAdd).toHaveBeenCalledWith('牛乳')
+  })
+
   it('完了切替ボタンでonToggleDoneを呼ぶ', async () => {
     const note = shoppingNote(1, '牛乳', false)
     const onToggleDone = vi.fn().mockResolvedValue(undefined)
@@ -81,12 +102,33 @@ describe('ShoppingList', () => {
       }
     })
 
-    expect(wrapper.text()).toContain('牛乳')
-    expect(wrapper.text()).not.toContain('完了メモ')
+    const listText = wrapper.find('ul.hd-list').text()
+    expect(listText).toContain('牛乳')
+    expect(listText).not.toContain('完了メモ')
 
     await wrapper.get('input[type="checkbox"]').setValue(true)
 
-    expect(wrapper.text()).toContain('完了メモ')
+    expect(wrapper.find('ul.hd-list').text()).toContain('完了メモ')
+  })
+
+  it('最近追加した項目は重複なく表示する', () => {
+    const wrapper = mount(ShoppingList, {
+      props: {
+        items: [
+          shoppingNote(1, '牛乳', false),
+          shoppingNote(2, '卵', false),
+          shoppingNote(3, '牛乳', true)
+        ],
+        pendingIds: [],
+        onAdd: vi.fn().mockResolvedValue(undefined),
+        onToggleDone: vi.fn().mockResolvedValue(undefined),
+        onDeleteNote: vi.fn().mockResolvedValue(undefined)
+      }
+    })
+
+    const recentTitle = wrapper.text()
+    expect(recentTitle).toContain('最近追加した項目')
+    expect(wrapper.findAll('button').filter((button) => button.text() === '牛乳')).toHaveLength(2)
   })
 
   it('削除確認ダイアログでキャンセル/削除が正しく動く', async () => {


### PR DESCRIPTION
## 概要
- 買い物メモに軽量な入力補助を追加しました
- 固定候補と最近追加した項目をチップで表示し、1タップで追加できるようにしました

## 変更点
- ShoppingList に固定候補チップを追加
- ShoppingList に最近追加した項目の再利用チップを追加
- 最近追加は重複を除いて新しい順に表示
- ShoppingList のテストを追加・更新

## 動作確認
- `npm --prefix web run test:run`
- `npm --prefix web run build`

## 影響範囲
- ShoppingList の入力UIのみ
- API / DB 変更なし

## チェックリスト
- [x] MVP0範囲外の機能は追加していない
- [x] 自動学習や外部連携は入れていない
- [x] フロントテストを追加・更新した

Closes #42